### PR TITLE
If access_token -> then app_key is not required

### DIFF
--- a/flo_ai/flo_ai/helpers/llm_factory.py
+++ b/flo_ai/flo_ai/helpers/llm_factory.py
@@ -230,10 +230,10 @@ class LLMFactory:
         return RootFloLLM(
             base_url=base_url,
             model_id=model_id,
-            app_key=None if access_token else app_key,
-            app_secret=None if access_token else app_secret,
-            issuer=None if access_token else issuer,
-            audience=None if access_token else audience,
+            app_key=app_key,
+            app_secret=app_secret,
+            issuer=issuer,
+            audience=audience,
             access_token=access_token,
         )
 

--- a/flo_ai/flo_ai/llm/rootflo_llm.py
+++ b/flo_ai/flo_ai/llm/rootflo_llm.py
@@ -140,8 +140,8 @@ class RootFloLLM(BaseLLM):
             'Authorization': f'Bearer {api_token}',
         }
 
-        # Only add X-Rootflo-Key header if app_key is provided and access_token is not used
-        if app_key and self._access_token is None:
+        # Only add X-Rootflo-Key header if app_key is provided
+        if app_key:
             headers['X-Rootflo-Key'] = app_key
 
         try:
@@ -231,11 +231,7 @@ class RootFloLLM(BaseLLM):
             full_url = f'{self._base_url}/v1/llm-inference/{self._model_id}'
 
             # Prepare custom headers for proxy authentication (only if app_key is provided)
-            custom_headers = (
-                {'X-Rootflo-Key': self._app_key}
-                if (self._app_key and self._access_token is None)
-                else {}
-            )
+            custom_headers = {'X-Rootflo-Key': self._app_key} if self._app_key else {}
 
             # Instantiate appropriate SDK wrapper based on llm_provider
             if llm_provider == LLMProvider.OPENAI:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RootFlo can be initialized with just a base URL and an access token; JWT fields (app key/secret/issuer/audience) are optional when using token-based auth.
  * Request headers will omit the app key header when no app key is provided.

* **Bug Fixes**
  * Validation and error messages clarified: missing base_url is explicitly reported; JWT-related fields are not required or validated when an access token is used.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->