### PR TITLE
fix: make worker count int

### DIFF
--- a/wavefront/server/apps/floware/floware/server.py
+++ b/wavefront/server/apps/floware/floware/server.py
@@ -560,7 +560,7 @@ if __name__ == '__main__':
             'server:app',
             host='0.0.0.0',
             port=8001,
-            workers=worker_count,
+            workers=int(worker_count),
             log_level=uvicorn_log_level,
             forwarded_allow_ips='*',
         )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the production server worker configuration to properly convert the worker count parameter to an integer value. This ensures the application server initializes correctly with the specified number of worker processes, preventing type-handling issues that could arise when loading configuration from environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->