### PR TITLE
fix: make odata search case insensitive

### DIFF
--- a/wavefront/server/plugins/datasource/datasource/odata_parser.py
+++ b/wavefront/server/plugins/datasource/datasource/odata_parser.py
@@ -353,9 +353,9 @@ class SQLFilterParser:
             return f'{field} {sql_op} {self.dynamic_var_char}{param_key}'
 
         elif operator == 'in':
-            # Parse array values
+            # Parse array values, lowercase for case-insensitive matching
             items = value.strip('[]').split(',')
-            parsed_values = [v.strip().strip('\'"') for v in items]
+            parsed_values = [v.strip().strip('\'"').lower() for v in items]
 
             placeholder_keys = []
             for idx, val in enumerate(parsed_values):
@@ -363,7 +363,7 @@ class SQLFilterParser:
                 self.params[item_key] = val
                 placeholder_keys.append(f'{self.dynamic_var_char}{item_key}')
 
-            return f"{field} IN ({', '.join(placeholder_keys)})"
+            return f"LOWER({field}) IN ({', '.join(placeholder_keys)})"
 
         else:
             parsed_value = self.parse_value(value)

--- a/wavefront/server/plugins/datasource/datasource/odata_parser.py
+++ b/wavefront/server/plugins/datasource/datasource/odata_parser.py
@@ -350,12 +350,12 @@ class SQLFilterParser:
         if operator == 'contains':
             parsed_value = self.parse_value(value)
             self.params[param_key] = f'%{parsed_value}%'
-            return f'{field} {sql_op} {self.dynamic_var_char}{param_key}'
+            return f'LOWER({field}) {sql_op} LOWER({self.dynamic_var_char}{param_key})'
 
         elif operator == 'in':
-            # Parse array values, lowercase for case-insensitive matching
+            # Parse array values
             items = value.strip('[]').split(',')
-            parsed_values = [v.strip().strip('\'"').lower() for v in items]
+            parsed_values = [v.strip().strip('\'"') for v in items]
 
             placeholder_keys = []
             for idx, val in enumerate(parsed_values):
@@ -363,7 +363,7 @@ class SQLFilterParser:
                 self.params[item_key] = val
                 placeholder_keys.append(f'{self.dynamic_var_char}{item_key}')
 
-            return f"LOWER({field}) IN ({', '.join(placeholder_keys)})"
+            return f"{field} IN ({', '.join(placeholder_keys)})"
 
         else:
             parsed_value = self.parse_value(value)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the "contains" filter operator to be case-insensitive, allowing searches to match regardless of character case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->