### PR TITLE
fix/dockeruser-683091438 : run uv/server as non-root user : (call-processing-docker)

### DIFF
--- a/wavefront/server/docker/call_processing.Dockerfile
+++ b/wavefront/server/docker/call_processing.Dockerfile
@@ -20,4 +20,9 @@ RUN uv sync --package call_processing --frozen --no-dev
 
 WORKDIR /app/apps/call_processing/call_processing
 
+# Add a non-root appuser, ensure ownership, and switch to that user before running the server
+RUN useradd -m appuser
+RUN chown -R appuser /app
+USER appuser
+
 CMD ["uv", "run", "server.py"]

--- a/wavefront/server/docker/floconsole.Dockerfile
+++ b/wavefront/server/docker/floconsole.Dockerfile
@@ -22,4 +22,13 @@ RUN chmod +x /app/scripts/console-server-init.sh
 
 RUN uv sync --package floconsole --frozen --no-dev
 
+# Add a new non-root user named 'appuser' with a home directory
+RUN useradd -m appuser
+
+# Give 'appuser' ownership of the /app directory and its contents
+RUN chown -R appuser:appuser /app
+
+# Switch to the non-root user for all subsequent instructions
+USER appuser
+
 ENTRYPOINT ["/app/scripts/console-server-init.sh"]

--- a/wavefront/server/docker/inference_app.Dockerfile
+++ b/wavefront/server/docker/inference_app.Dockerfile
@@ -21,4 +21,13 @@ RUN uv sync --package inference-app --frozen --no-dev
 
 WORKDIR /app/apps/inference_app/inference_app
 
+# Create a non-root user 'appuser' with a home directory
+RUN useradd -m appuser
+
+# Change ownership of the /app directory to 'appuser' to ensure permission
+RUN chown -R appuser:appuser /app
+
+# Ensure subsequent actions run as 'appuser'
+USER appuser
+
 CMD ["uv", "run", "server.py"]

--- a/wavefront/server/docker/workflow.Dockerfile
+++ b/wavefront/server/docker/workflow.Dockerfile
@@ -30,7 +30,16 @@ COPY wavefront/server/plugins/authenticator /app/plugins/authenticator
 # Install dependencies (without dependecy resolution and no dev dependencies)
 RUN uv sync --package workflow_job --frozen --no-dev
 
+# Create a non-root user named 'appuser'
+RUN useradd -m appuser
+
+# Ensure that /app is owned by 'appuser'
+RUN chown -R appuser /app
+
 # change WORKDIR
 WORKDIR /app/background_jobs/workflow_job/workflow_job
+
+# Switch to the non-root user before running the command
+USER appuser
 
 CMD ["uv", "run", "main.py"]

--- a/wavefront/server/docker/workflow.Dockerfile
+++ b/wavefront/server/docker/workflow.Dockerfile
@@ -33,8 +33,8 @@ RUN uv sync --package workflow_job --frozen --no-dev
 # Create a non-root user named 'appuser'
 RUN useradd -m appuser
 
-# Ensure that /app is owned by 'appuser'
-RUN chown -R appuser /app
+# Give 'appuser' ownership of the /app directory and its contents
+RUN chown -R appuser:appuser /app
 
 # change WORKDIR
 WORKDIR /app/background_jobs/workflow_job/workflow_job


### PR DESCRIPTION
modified docker images as unprivileged users instead of root
semgrep issue #683091438 ,#683091436, #683091435, #712776833


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved container security for server components by switching runtime to a non-root account and updating /app ownership so services run with restricted permissions. Behavior and entrypoints remain unchanged while reducing privilege exposure across affected images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->