### PR TITLE
gold: accept only base64 data URLs for image analyse and historical uploads

### DIFF
--- a/wavefront/server/modules/gold_module/gold_module/controllers/image_controller.py
+++ b/wavefront/server/modules/gold_module/gold_module/controllers/image_controller.py
@@ -1,6 +1,5 @@
 import base64
 import re
-import httpx
 
 from common_module.common_container import CommonContainer
 from common_module.response_formatter import ResponseFormatter
@@ -54,31 +53,11 @@ async def process_image(
                     'Invalid base64 image encoding'
                 ),
             )
-    elif image_str.startswith('http://') or image_str.startswith('https://'):
-        # Download the image from the URL
-        try:
-            async with httpx.AsyncClient() as client:
-                resp = await client.get(image_str)
-                if resp.status_code != 200:
-                    return JSONResponse(
-                        status_code=status.HTTP_400_BAD_REQUEST,
-                        content=response_formatter.buildErrorResponse(
-                            'Failed to download image from URL'
-                        ),
-                    )
-                gold_image = resp.content
-        except Exception:
-            return JSONResponse(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                content=response_formatter.buildErrorResponse(
-                    'Error downloading image from URL'
-                ),
-            )
     else:
         return JSONResponse(
             status_code=status.HTTP_400_BAD_REQUEST,
             content=response_formatter.buildErrorResponse(
-                'Image must be a data URL or a direct image URL'
+                'Image must be a data URL (data:image/<type>;base64,<data>)'
             ),
         )
     if not gold_image:
@@ -119,31 +98,11 @@ async def upload_historical_images(
                     'Invalid base64 image encoding'
                 ),
             )
-    elif image_str.startswith('http://') or image_str.startswith('https://'):
-        # Download the image from the URL
-        try:
-            async with httpx.AsyncClient() as client:
-                resp = await client.get(image_str)
-                if resp.status_code != 200:
-                    return JSONResponse(
-                        status_code=status.HTTP_400_BAD_REQUEST,
-                        content=response_formatter.buildErrorResponse(
-                            'Failed to download image from URL'
-                        ),
-                    )
-                gold_image = resp.content
-        except Exception:
-            return JSONResponse(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                content=response_formatter.buildErrorResponse(
-                    'Error downloading image from URL'
-                ),
-            )
     else:
         return JSONResponse(
             status_code=status.HTTP_400_BAD_REQUEST,
             content=response_formatter.buildErrorResponse(
-                'Image must be a data URL or a direct image URL'
+                 'Image must be a data URL (data:image/<type>;base64,<data>)'
             ),
         )
     if not gold_image:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Image upload endpoints now exclusively accept base64-encoded data URLs (`data:image/<type>;base64,<data>`)
  * HTTP/HTTPS image URLs are no longer supported for `/analyse` and `/historical_images` endpoints
  * Error messages updated to explicitly specify required data URL format

<!-- end of auto-generated comment: release notes by coderabbit.ai -->