### PR TITLE
feat: add PostgreSQL datasource support

### DIFF
--- a/wavefront/client/src/pages/apps/[appId]/datasources/CreateDatasourceDialog.tsx
+++ b/wavefront/client/src/pages/apps/[appId]/datasources/CreateDatasourceDialog.tsx
@@ -25,6 +25,7 @@ import { createDatasourceSchema, type CreateDatasourceInput } from './schemas';
 const DATASOURCE_TYPES = [
   { value: 'gcp_bigquery', label: 'Google BigQuery' },
   { value: 'aws_redshift', label: 'AWS Redshift' },
+  { value: 'postgres', label: 'PostgreSQL' },
 ];
 
 const SAMPLE_CONFIGS = {
@@ -41,6 +42,14 @@ const SAMPLE_CONFIGS = {
     database: 'your-database',
     user: 'your-username',
     password: 'your-password',
+  },
+  postgres: {
+    host: 'localhost',
+    port: 5432,
+    database: 'your-database',
+    user: 'your-username',
+    password: 'your-password',
+    schema: 'public',
   },
 };
 

--- a/wavefront/client/src/pages/apps/[appId]/datasources/EditDatasourceDialog.tsx
+++ b/wavefront/client/src/pages/apps/[appId]/datasources/EditDatasourceDialog.tsx
@@ -25,6 +25,7 @@ import { createDatasourceSchema, type CreateDatasourceInput } from './schemas';
 const DATASOURCE_TYPES = [
   { value: 'gcp_bigquery', label: 'Google BigQuery' },
   { value: 'aws_redshift', label: 'AWS Redshift' },
+  { value: 'postgres', label: 'PostgreSQL' },
 ];
 
 interface EditDatasourceDialogProps {
@@ -59,7 +60,7 @@ const EditDatasourceDialog: React.FC<EditDatasourceDialogProps> = ({
     if (datasource && isOpen) {
       form.reset({
         name: datasource.name || '',
-        type: (datasource.type as 'gcp_bigquery' | 'aws_redshift') || 'gcp_bigquery',
+        type: (datasource.type as 'gcp_bigquery' | 'aws_redshift' | 'postgres') || 'gcp_bigquery',
         description: datasource.description || '',
         connectionConfig: JSON.stringify(datasource.config || {}, null, 2),
       });

--- a/wavefront/client/src/pages/apps/[appId]/datasources/schemas.ts
+++ b/wavefront/client/src/pages/apps/[appId]/datasources/schemas.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 export const createDatasourceSchema = z.object({
   name: z.string().min(1, 'Datasource name is required'),
-  type: z.enum(['gcp_bigquery', 'aws_redshift']),
+  type: z.enum(['gcp_bigquery', 'aws_redshift', 'postgres']),
   description: z.string().optional(),
   connectionConfig: z
     .string()

--- a/wavefront/server/modules/plugins_module/plugins_module/controllers/datasource_controller.py
+++ b/wavefront/server/modules/plugins_module/plugins_module/controllers/datasource_controller.py
@@ -1,6 +1,7 @@
 from typing import Dict, Any
 from datasource.bigquery.config import BigQueryConfig
 from datasource.redshift.config import RedshiftConfig
+from datasource.postgres.config import PostgresConfig
 from dependency_injector.wiring import inject
 import json
 from dependency_injector.wiring import Provide
@@ -90,6 +91,8 @@ async def add_datasource(
         config = BigQueryConfig(**config_json)
     elif add_datasource_payload.type == DataSourceType.AWS_REDSHIFT:
         config = RedshiftConfig(**config_json)
+    elif add_datasource_payload.type == DataSourceType.POSTGRES:
+        config = PostgresConfig(**config_json)
     else:
         raise ValueError(f'Invalid datasource type: {add_datasource_payload.type}')
 
@@ -181,6 +184,8 @@ async def update_datasource(
                 config = BigQueryConfig(**payload_config)
             elif datasource_type == DataSourceType.AWS_REDSHIFT:
                 config = RedshiftConfig(**payload_config)
+            elif datasource_type == DataSourceType.POSTGRES:
+                config = PostgresConfig(**payload_config)
             else:
                 raise ValueError(f'Invalid datasource type: {datasource_type}')
 

--- a/wavefront/server/modules/plugins_module/plugins_module/services/datasource_services.py
+++ b/wavefront/server/modules/plugins_module/plugins_module/services/datasource_services.py
@@ -1,5 +1,5 @@
 import collections
-from datasource import DataSourceType, BigQueryConfig, RedshiftConfig
+from datasource import DataSourceType, BigQueryConfig, RedshiftConfig, PostgresConfig
 from db_repo_module.models.datasource import Datasource
 from db_repo_module.models.role import Role
 from db_repo_module.repositories.sql_alchemy_repository import SQLAlchemyRepository
@@ -17,7 +17,7 @@ async def get_datasource_config(
     datasource_repository: SQLAlchemyRepository[Datasource] = Depends(
         Provide(PluginsContainer.datasource_repository)
     ),
-) -> tuple[DataSourceType, BigQueryConfig | RedshiftConfig]:
+) -> tuple[DataSourceType, BigQueryConfig | RedshiftConfig | PostgresConfig]:
     datasource: Datasource | None = await datasource_repository.find_one(
         id=datasource_id
     )
@@ -28,6 +28,8 @@ async def get_datasource_config(
         return DataSourceType.GCP_BIGQUERY, BigQueryConfig(**datasource.config)
     elif datasource.type == DataSourceType.AWS_REDSHIFT:
         return DataSourceType.AWS_REDSHIFT, RedshiftConfig(**datasource.config)
+    elif datasource.type == DataSourceType.POSTGRES:
+        return DataSourceType.POSTGRES, PostgresConfig(**datasource.config)
     else:
         raise ValueError(f'Invalid datasource type: {datasource.type}')
 

--- a/wavefront/server/packages/flo_cloud/flo_cloud/postgres/__init__.py
+++ b/wavefront/server/packages/flo_cloud/flo_cloud/postgres/__init__.py
@@ -1,0 +1,3 @@
+from .postgres import PostgresClient
+
+__all__ = ['PostgresClient']

--- a/wavefront/server/packages/flo_cloud/flo_cloud/postgres/postgres.py
+++ b/wavefront/server/packages/flo_cloud/flo_cloud/postgres/postgres.py
@@ -6,6 +6,7 @@ from contextlib import contextmanager
 
 import psycopg2
 import psycopg2.extras
+from psycopg2 import sql
 
 logger = logging.getLogger(__name__)
 
@@ -113,7 +114,7 @@ class PostgresClient:
         self,
         projection: str = '*',
         table_prefix: str = '',
-        table_names: List[str] = [],
+        table_names: Optional[List[str]] = None,
         where_clause: str = 'true',
         join_query: Optional[str] = None,
         params: Optional[Dict[str, Any]] = None,
@@ -176,11 +177,14 @@ class PostgresClient:
         for i, table_name in enumerate(table_names):
             alias = aliases[i]
             qualified = f'{table_prefix}{table_name}'
-            processed_join = processed_join.replace(
-                f'JOIN {table_name}', f'LEFT JOIN {qualified} AS {alias}'
+            escaped = re.escape(table_name)
+            processed_join = re.sub(
+                rf'\bJOIN\s+{escaped}\b',
+                f'LEFT JOIN {qualified} AS {alias}',
+                processed_join,
             )
-            processed_join = processed_join.replace(f'{table_name}.', f'{alias}.')
-            processed_where = processed_where.replace(f'{table_name}.', f'{alias}.')
+            processed_join = re.sub(rf'\b{escaped}\.', f'{alias}.', processed_join)
+            processed_where = re.sub(rf'\b{escaped}\.', f'{alias}.', processed_where)
 
         group_by_clause = f'GROUP BY {group_by}' if group_by else ''
         order_by_clause = f'ORDER BY {order_by}' if order_by else ''
@@ -245,9 +249,11 @@ class PostgresClient:
             for row in data
         ]
         columns = list(serialized[0].keys())
-        col_str = ', '.join(columns)
-        val_str = ', '.join(f'%({col})s' for col in columns)
-        query = f'INSERT INTO {table_name} ({col_str}) VALUES ({val_str})'
+        query = sql.SQL('INSERT INTO {table} ({cols}) VALUES ({vals})').format(
+            table=sql.Identifier(*table_name.split('.')),
+            cols=sql.SQL(', ').join(map(sql.Identifier, columns)),
+            vals=sql.SQL(', ').join(sql.Placeholder(name=col) for col in columns),
+        )
         with self.get_connection() as conn:
             cursor = conn.cursor()
             try:

--- a/wavefront/server/packages/flo_cloud/flo_cloud/postgres/postgres.py
+++ b/wavefront/server/packages/flo_cloud/flo_cloud/postgres/postgres.py
@@ -159,6 +159,27 @@ class PostgresClient:
             logger.error(f'Postgres query execution error: {e}')
             raise
 
+    @staticmethod
+    def _qualify_unaliased_columns(clause: str, default_alias: str) -> str:
+        """Prefix unqualified column tokens with default_alias to avoid ambiguity in JOINs."""
+        if not clause:
+            return clause
+        _DIRECTION_KEYWORDS = {'ASC', 'DESC', 'NULLS', 'FIRST', 'LAST'}
+        parts = clause.split(',')
+        result = []
+        for part in parts:
+            tokens = part.strip().split()
+            new_tokens = []
+            for token in tokens:
+                if token.upper() in _DIRECTION_KEYWORDS:
+                    new_tokens.append(token)
+                elif '.' not in token and re.match(r'^[A-Za-z_][A-Za-z0-9_]*$', token):
+                    new_tokens.append(f'{default_alias}.{token}')
+                else:
+                    new_tokens.append(token)
+            result.append(' '.join(new_tokens))
+        return ', '.join(result)
+
     def __get_join_query(
         self,
         join_query: str,
@@ -174,6 +195,8 @@ class PostgresClient:
         aliases = list(string.ascii_lowercase)
         processed_join = join_query
         processed_where = where_clause
+        processed_order_by = order_by or ''
+        processed_group_by = group_by or ''
         for i, table_name in enumerate(table_names):
             alias = aliases[i]
             qualified = f'{table_prefix}{table_name}'
@@ -185,9 +208,22 @@ class PostgresClient:
             )
             processed_join = re.sub(rf'\b{escaped}\.', f'{alias}.', processed_join)
             processed_where = re.sub(rf'\b{escaped}\.', f'{alias}.', processed_where)
+            processed_order_by = re.sub(
+                rf'\b{escaped}\.', f'{alias}.', processed_order_by
+            )
+            processed_group_by = re.sub(
+                rf'\b{escaped}\.', f'{alias}.', processed_group_by
+            )
 
-        group_by_clause = f'GROUP BY {group_by}' if group_by else ''
-        order_by_clause = f'ORDER BY {order_by}' if order_by else ''
+        processed_order_by = self._qualify_unaliased_columns(
+            processed_order_by, aliases[0]
+        )
+        processed_group_by = self._qualify_unaliased_columns(
+            processed_group_by, aliases[0]
+        )
+
+        group_by_clause = f'GROUP BY {processed_group_by}' if processed_group_by else ''
+        order_by_clause = f'ORDER BY {processed_order_by}' if processed_order_by else ''
         base_table = f'{table_prefix}{table_names[0]}'
         return (
             f'SELECT {projection} FROM {base_table} AS {aliases[0]} '

--- a/wavefront/server/packages/flo_cloud/flo_cloud/postgres/postgres.py
+++ b/wavefront/server/packages/flo_cloud/flo_cloud/postgres/postgres.py
@@ -1,0 +1,261 @@
+import re
+import string
+import logging
+from typing import List, Dict, Any, Optional, Tuple
+from contextlib import contextmanager
+
+import psycopg2
+import psycopg2.extras
+
+logger = logging.getLogger(__name__)
+
+
+class PostgresClient:
+    def __init__(
+        self,
+        host: str,
+        port: int = 5432,
+        database: str = None,
+        user: str = None,
+        password: str = None,
+        schema: str = 'public',
+        ssl: bool = False,
+        timeout: int = 60,
+    ):
+        self.host = host
+        self.port = port
+        self.database = database
+        self.user = user
+        self.password = password
+        self.schema = schema
+        self.ssl = ssl
+        self.timeout = timeout
+
+    def _get_connection_params(self) -> Dict[str, Any]:
+        params: Dict[str, Any] = {
+            'host': self.host,
+            'port': self.port,
+            'dbname': self.database,
+            'user': self.user,
+            'password': self.password,
+            'connect_timeout': self.timeout,
+        }
+        if self.ssl:
+            params['sslmode'] = 'require'
+        return params
+
+    def _convert_named_params(
+        self, query: str, params: Optional[Dict[str, Any]]
+    ) -> Tuple[str, Optional[Dict[str, Any]]]:
+        """Convert :name style placeholders to %(name)s for psycopg2."""
+        if not params:
+            return query, params
+        converted = re.sub(r'(?<!:):([A-Za-z_][A-Za-z0-9_]*)', r'%(\1)s', query)
+        return converted, params
+
+    @contextmanager
+    def get_connection(self):
+        connection = None
+        try:
+            connection = psycopg2.connect(**self._get_connection_params())
+            yield connection
+        except psycopg2.Error as e:
+            logger.error(f'Postgres connection error: {e}')
+            raise
+        finally:
+            if connection:
+                connection.close()
+
+    @contextmanager
+    def get_cursor(self, connection=None):
+        if connection:
+            cursor = connection.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
+            try:
+                yield cursor
+            finally:
+                cursor.close()
+        else:
+            with self.get_connection() as conn:
+                cursor = conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
+                try:
+                    yield cursor
+                finally:
+                    cursor.close()
+
+    def execute_query(
+        self, query: str, params: Optional[Dict[str, Any]] = None
+    ) -> List[Tuple]:
+        query, params = self._convert_named_params(query, params)
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            try:
+                cursor.execute(query, params)
+                return cursor.fetchall()
+            except psycopg2.Error as e:
+                logger.error(f'Query execution error: {e}')
+                raise
+            finally:
+                cursor.close()
+
+    def execute_query_as_dict(
+        self, query: str, params: Optional[Dict[str, Any]] = None
+    ) -> List[Dict[str, Any]]:
+        query, params = self._convert_named_params(query, params)
+        with self.get_cursor() as cursor:
+            try:
+                cursor.execute(query, params)
+                return [dict(row) for row in cursor.fetchall()]
+            except psycopg2.Error as e:
+                logger.error(f'Query execution error: {e}')
+                raise
+
+    def execute_query_to_dict(
+        self,
+        projection: str = '*',
+        table_prefix: str = '',
+        table_names: List[str] = [],
+        where_clause: str = 'true',
+        join_query: Optional[str] = None,
+        params: Optional[Dict[str, Any]] = None,
+        limit: int = 10,
+        offset: int = 0,
+        order_by: Optional[str] = None,
+        group_by: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        if not table_names:
+            raise ValueError('At least one table name must be provided')
+
+        base_table = f'{table_prefix}{table_names[0]}'
+        group_by_clause = f'GROUP BY {group_by}' if group_by else ''
+        order_by_clause = f'ORDER BY {order_by}' if order_by else ''
+
+        if join_query:
+            query = self.__get_join_query(
+                join_query,
+                table_names,
+                table_prefix,
+                projection,
+                where_clause,
+                limit,
+                offset,
+                order_by,
+                group_by,
+            )
+        else:
+            query = (
+                f'SELECT {projection} FROM {base_table} AS a '
+                f'WHERE {where_clause} {group_by_clause} {order_by_clause} '
+                f'LIMIT {limit} OFFSET {offset}'
+            )
+
+        query, params = self._convert_named_params(query, params)
+        try:
+            logger.debug(f'Executing query: {query}')
+            with self.get_cursor() as cursor:
+                cursor.execute(query, params)
+                return [dict(row) for row in cursor.fetchall()]
+        except psycopg2.Error as e:
+            logger.error(f'Postgres query execution error: {e}')
+            raise
+
+    def __get_join_query(
+        self,
+        join_query: str,
+        table_names: List[str],
+        table_prefix: str,
+        projection: str,
+        where_clause: str,
+        limit: int,
+        offset: int,
+        order_by: Optional[str] = None,
+        group_by: Optional[str] = None,
+    ) -> str:
+        aliases = list(string.ascii_lowercase)
+        processed_join = join_query
+        processed_where = where_clause
+        for i, table_name in enumerate(table_names):
+            alias = aliases[i]
+            qualified = f'{table_prefix}{table_name}'
+            processed_join = processed_join.replace(
+                f'JOIN {table_name}', f'LEFT JOIN {qualified} AS {alias}'
+            )
+            processed_join = processed_join.replace(f'{table_name}.', f'{alias}.')
+            processed_where = processed_where.replace(f'{table_name}.', f'{alias}.')
+
+        group_by_clause = f'GROUP BY {group_by}' if group_by else ''
+        order_by_clause = f'ORDER BY {order_by}' if order_by else ''
+        base_table = f'{table_prefix}{table_names[0]}'
+        return (
+            f'SELECT {projection} FROM {base_table} AS {aliases[0]} '
+            f'{processed_join} WHERE {processed_where} '
+            f'{group_by_clause} {order_by_clause} '
+            f'LIMIT {limit} OFFSET {offset}'
+        )
+
+    def list_tables(self, schema: Optional[str] = None) -> List[str]:
+        schema = schema or self.schema
+        query = """
+        SELECT table_name
+        FROM information_schema.tables
+        WHERE table_schema = %(table_schema)s AND table_type = 'BASE TABLE'
+        ORDER BY table_name
+        """
+        results = self.execute_query(query, {'table_schema': schema})
+        return [row[0] for row in results]
+
+    def get_table_info(self, table_name: str) -> Dict[str, Any]:
+        query = """
+        SELECT
+            column_name,
+            data_type,
+            character_maximum_length,
+            numeric_precision,
+            numeric_scale,
+            is_nullable,
+            column_default,
+            ordinal_position
+        FROM information_schema.columns
+        WHERE table_name = %(table_name)s AND table_schema = %(table_schema)s
+        ORDER BY ordinal_position
+        """
+        columns = self.execute_query_as_dict(
+            query, {'table_name': table_name, 'table_schema': self.schema}
+        )
+        return {'table_name': table_name, 'columns': columns}
+
+    def test_connection(self) -> bool:
+        try:
+            result = self.execute_query('SELECT 1')
+            success = len(result) > 0 and result[0][0] == 1
+            if success:
+                logger.info('Postgres connection test successful')
+            return success
+        except Exception as e:
+            logger.error(f'Postgres connection test failed: {e}')
+            return False
+
+    def insert_rows_json(self, table_name: str, data: List[Dict[str, Any]]) -> None:
+        if not data:
+            return
+        serialized = [
+            {
+                k: psycopg2.extras.Json(v) if isinstance(v, (dict, list)) else v
+                for k, v in row.items()
+            }
+            for row in data
+        ]
+        columns = list(serialized[0].keys())
+        col_str = ', '.join(columns)
+        val_str = ', '.join(f'%({col})s' for col in columns)
+        query = f'INSERT INTO {table_name} ({col_str}) VALUES ({val_str})'
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            try:
+                cursor.executemany(query, serialized)
+                conn.commit()
+            except psycopg2.Error as e:
+                conn.rollback()
+                logger.error(f'Insert error: {e}')
+                raise
+            finally:
+                cursor.close()

--- a/wavefront/server/packages/flo_cloud/flo_cloud/postgres/postgres.py
+++ b/wavefront/server/packages/flo_cloud/flo_cloud/postgres/postgres.py
@@ -59,6 +59,13 @@ class PostgresClient:
         connection = None
         try:
             connection = psycopg2.connect(**self._get_connection_params())
+            if self.schema:
+                with connection.cursor() as cursor:
+                    cursor.execute(
+                        sql.SQL('SET search_path TO {}').format(
+                            sql.Identifier(self.schema)
+                        )
+                    )
             yield connection
         except psycopg2.Error as e:
             logger.error(f'Postgres connection error: {e}')
@@ -222,12 +229,68 @@ class PostgresClient:
             processed_group_by, aliases[0]
         )
 
-        group_by_clause = f'GROUP BY {processed_group_by}' if processed_group_by else ''
+        # Separate parent (a.*) columns from child columns, mirroring BigQuery's
+        # ARRAY_AGG(STRUCT(...)) pattern but using json_agg(json_build_object(...))
+        parent_cols = []
+        child_projections: Dict[
+            str, List[tuple]
+        ] = {}  # alias -> [(col_name, col_expr)]
+
+        for col in projection.split(','):
+            col = col.strip()
+            if not col or col == '*':
+                continue
+            if '.' in col:
+                tbl_alias, col_name = col.split('.', 1)
+                if tbl_alias == aliases[0]:
+                    parent_cols.append(col)
+                else:
+                    child_projections.setdefault(tbl_alias, []).append((col_name, col))
+            else:
+                parent_cols.append(col)
+
         order_by_clause = f'ORDER BY {processed_order_by}' if processed_order_by else ''
         base_table = f'{table_prefix}{table_names[0]}'
+
+        if not child_projections:
+            # No child columns — plain flat query
+            group_by_clause = (
+                f'GROUP BY {processed_group_by}' if processed_group_by else ''
+            )
+            return (
+                f'SELECT {projection} FROM {base_table} AS {aliases[0]} '
+                f'{processed_join} WHERE {processed_where} '
+                f'{group_by_clause} {order_by_clause} '
+                f'LIMIT {limit} OFFSET {offset}'
+            )
+
+        # Build correlated subqueries for child tables — avoids GROUP BY on parent columns
+        join_conditions = {}
+        for m in re.finditer(
+            r'LEFT JOIN\s+\S+\s+AS\s+(\w+)\s+ON\s+((?:(?!LEFT JOIN).)+)',
+            processed_join,
+            re.IGNORECASE | re.DOTALL,
+        ):
+            join_conditions[m.group(1)] = m.group(2).strip()
+
+        subquery_parts = []
+        for alias_key, cols in child_projections.items():
+            child_idx = aliases.index(alias_key)
+            child_table_name = table_names[child_idx]
+            full_qualified = f'{table_prefix}{child_table_name}'
+            json_args = ', '.join(f"'{name}', {expr}" for name, expr in cols)
+            cond = join_conditions.get(alias_key, 'TRUE')
+            subquery_parts.append(
+                f'(SELECT json_agg(json_build_object({json_args})) '
+                f'FROM {full_qualified} AS {alias_key} WHERE {cond}) AS {child_table_name}'
+            )
+
+        parent_select = ', '.join(parent_cols) if parent_cols else f'{aliases[0]}.*'
+        group_by_clause = f'GROUP BY {processed_group_by}' if processed_group_by else ''
         return (
-            f'SELECT {projection} FROM {base_table} AS {aliases[0]} '
-            f'{processed_join} WHERE {processed_where} '
+            f'SELECT {parent_select}, {", ".join(subquery_parts)} '
+            f'FROM {base_table} AS {aliases[0]} '
+            f'WHERE {processed_where} '
             f'{group_by_clause} {order_by_clause} '
             f'LIMIT {limit} OFFSET {offset}'
         )

--- a/wavefront/server/plugins/datasource/datasource/__init__.py
+++ b/wavefront/server/plugins/datasource/datasource/__init__.py
@@ -9,6 +9,7 @@ from typing import Any, Optional, List, Dict
 
 from .bigquery import BigQueryPlugin, BigQueryConfig
 from .redshift import RedshiftPlugin, RedshiftConfig
+from .postgres import PostgresPlugin, PostgresConfig
 from .helper import construct_meta
 from .odata_parser import ODataQueryParser
 
@@ -17,7 +18,7 @@ class DatasourcePlugin:
     def __init__(
         self,
         datasource_type: DataSourceType,
-        config: BigQueryConfig | RedshiftConfig,
+        config: BigQueryConfig | RedshiftConfig | PostgresConfig,
     ):
         self.datasource_type = datasource_type
         self.config = config
@@ -34,6 +35,11 @@ class DatasourcePlugin:
             if not isinstance(self.config, BigQueryConfig):
                 raise ValueError(f'Invalid config type: {type(self.config)}')
             return BigQueryPlugin(self.config)
+        elif self.datasource_type == DataSourceType.POSTGRES:
+            self.odata_parser = ODataQueryParser(type='sql', dynamic_var_char=':')
+            if not isinstance(self.config, PostgresConfig):
+                raise ValueError(f'Invalid config type: {type(self.config)}')
+            return PostgresPlugin(self.config)
         else:
             raise ValueError(f'Invalid datasource type: {self.datasource_type}')
 

--- a/wavefront/server/plugins/datasource/datasource/postgres/__init__.py
+++ b/wavefront/server/plugins/datasource/datasource/postgres/__init__.py
@@ -1,0 +1,144 @@
+import asyncio
+from typing import Any, Dict, List, Optional
+
+from ..types import DataSourceABC
+from flo_cloud.postgres import PostgresClient
+from .config import PostgresConfig
+
+
+class PostgresPlugin(DataSourceABC):
+    def __init__(self, config: PostgresConfig):
+        self.config = config
+        self.client = PostgresClient(
+            host=config.host,
+            port=config.port,
+            database=config.database,
+            user=config.user,
+            password=config.password,
+            schema=config.schema,
+        )
+        self.db_name = f'{config.database}.{config.schema}'
+
+    async def test_connection(self) -> bool:
+        return await asyncio.to_thread(self.client.test_connection)
+
+    def get_schema(self) -> dict:
+        table_names = self.client.list_tables()
+        return {
+            table_name: self.client.get_table_info(table_name)
+            for table_name in table_names
+        }
+
+    def get_table_names(self, **kwargs) -> list[str]:
+        schema = kwargs.get('schema', self.config.schema)
+        return self.client.list_tables(schema=schema)
+
+    def fetch_data(
+        self,
+        table_names: List[str],
+        projection: Optional[str] = '*',
+        where_clause: Optional[str] = 'true',
+        join_query: Optional[str] = None,
+        params: Optional[Dict[str, Any]] = None,
+        offset: Optional[int] = 0,
+        limit: Optional[int] = 10,
+        order_by: Optional[str] = None,
+        group_by: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        return self.client.execute_query_to_dict(
+            projection=projection or '*',
+            table_prefix=f'{self.config.schema}.',
+            table_names=table_names,
+            where_clause=where_clause or 'true',
+            join_query=join_query,
+            params=params,
+            limit=limit if limit is not None else 10,
+            offset=offset if offset is not None else 0,
+            order_by=order_by,
+            group_by=group_by,
+        )
+
+    def insert_rows_json(self, table_name: str, data: List[Dict[str, Any]]) -> None:
+        self.client.insert_rows_json(table_name, data)
+
+    async def execute_query(
+        self, query: str, use_legacy_sql: bool = False, dry_run: bool = False, **kwargs
+    ) -> Any:
+        params = kwargs.get('params')
+        return await asyncio.to_thread(self.client.execute_query_as_dict, query, params)
+
+    async def execute_dynamic_query(
+        self,
+        query: List[Dict[str, Any]],
+        odata_filter: Optional[str] = None,
+        odata_params: Optional[Dict[str, Any]] = None,
+        odata_data_filter: Optional[str] = None,
+        odata_data_params: Optional[Dict[str, Any]] = None,
+        offset: Optional[int] = 0,
+        limit: Optional[int] = 100,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        results = {}
+        tasks = []
+
+        for query_obj in query:
+            query_to_execute = query_obj.get('query', '')
+            query_params = query_obj.get('parameters', {})
+            query_id = query_obj.get('id')
+            if not query_id:
+                raise ValueError('Query ID is required')
+
+            params_key = [p['name'] for p in query_params]
+            params_to_execute: Dict[str, Any] = {}
+
+            if params is None:
+                params = {}
+
+            for key in params_key:
+                if key not in params:
+                    raise ValueError(f'Missing parameter: {key} for query {query_id}')
+                params_to_execute[key] = params[key]
+
+            if odata_params:
+                params_to_execute.update(odata_params)
+            if odata_data_params:
+                params_to_execute.update(odata_data_params)
+
+            query_to_execute = query_to_execute.replace(
+                '{{rls}}', f'{odata_data_filter}' if odata_data_filter else 'TRUE'
+            )
+            query_to_execute = query_to_execute.replace(
+                '{{filters}}', f'{odata_filter}' if odata_filter else 'TRUE'
+            )
+            query_to_execute += f' LIMIT {limit} OFFSET {offset}'
+
+            task = asyncio.create_task(
+                asyncio.to_thread(
+                    self.client.execute_query_as_dict,
+                    query_to_execute,
+                    params_to_execute,
+                )
+            )
+            tasks.append((query_id, task))
+
+        for query_id, task in tasks:
+            try:
+                formatted_result = await task
+                results[query_id] = {
+                    'status': 'success',
+                    'error': None,
+                    'description': f'Query {query_id} executed successfully',
+                    'result': formatted_result,
+                }
+            except Exception as e:
+                results[query_id] = {
+                    'status': 'error',
+                    'error': str(e),
+                    'description': f'Error executing query {query_id}',
+                    'result': [],
+                }
+
+        return results
+
+
+__all__ = ['PostgresPlugin', 'PostgresConfig']

--- a/wavefront/server/plugins/datasource/datasource/postgres/__init__.py
+++ b/wavefront/server/plugins/datasource/datasource/postgres/__init__.py
@@ -1,4 +1,5 @@
 import asyncio
+import re
 from typing import Any, Dict, List, Optional
 
 from ..types import DataSourceABC
@@ -83,11 +84,13 @@ class PostgresPlugin(DataSourceABC):
 
         for query_obj in query:
             query_to_execute = query_obj.get('query', '')
-            query_params = query_obj.get('parameters', {})
+            query_params = query_obj.get('parameters', [])
             query_id = query_obj.get('id')
             if not query_id:
                 raise ValueError('Query ID is required')
 
+            if not isinstance(query_params, list):
+                raise ValueError(f'parameters for query {query_id} must be a list')
             params_key = [p['name'] for p in query_params]
             params_to_execute: Dict[str, Any] = {}
 
@@ -110,7 +113,24 @@ class PostgresPlugin(DataSourceABC):
             query_to_execute = query_to_execute.replace(
                 '{{filters}}', f'{odata_filter}' if odata_filter else 'TRUE'
             )
-            query_to_execute += f' LIMIT {limit} OFFSET {offset}'
+            query_to_execute = query_to_execute.rstrip().rstrip(';')
+            depth = 0
+            has_top_level_limit = False
+            for token in re.split(r'(\(|\))', query_to_execute):
+                if token == '(':
+                    depth += 1
+                elif token == ')':
+                    depth -= 1
+                elif depth == 0 and re.search(r'\bLIMIT\b', token, re.IGNORECASE):
+                    has_top_level_limit = True
+                    break
+            if has_top_level_limit:
+                query_to_execute = (
+                    f'SELECT * FROM ({query_to_execute}) AS _sub'
+                    f' LIMIT {limit} OFFSET {offset}'
+                )
+            else:
+                query_to_execute += f' LIMIT {limit} OFFSET {offset}'
 
             task = asyncio.create_task(
                 asyncio.to_thread(

--- a/wavefront/server/plugins/datasource/datasource/postgres/config.py
+++ b/wavefront/server/plugins/datasource/datasource/postgres/config.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass, field
+
+
+@dataclass
+class PostgresConfig:
+    host: str
+    port: int
+    database: str
+    user: str
+    password: str
+    schema: str = field(default='public')


### PR DESCRIPTION
Add PostgreSQL as a supported datasource type across the full stack.

- flo_cloud: add cloud-agnostic PostgresClient (psycopg2, named param conversion with :: cast safety, JSONB serialization for insert)
- datasource plugin: PostgresConfig + PostgresPlugin implementing DataSourceABC
- Register DataSourceType.POSTGRES in DatasourcePlugin (dynamic_var_char=':')
- datasource_services: get_datasource_config handles POSTGRES
- datasource_controller: add/update datasource endpoints handle POSTGRES

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PostgreSQL datasource support added.
  * Connect to and query PostgreSQL databases (sync + async execution).
  * Insert JSON rows into PostgreSQL tables.
  * Browse tables and view column metadata.
  * Advanced querying: joins, filters, pagination, ordering, grouping, and aggregated child rows.
  * Connection testing with clearer success/failure feedback.
  * PostgreSQL option available in datasource create/edit UIs and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->