### PR TITLE
added async agentic inf - Celery + Redis Streams

### DIFF
--- a/wavefront/server/apps/floware/floware/config.ini
+++ b/wavefront/server/apps/floware/floware/config.ini
@@ -149,6 +149,7 @@ enabled=${LEADS_ENABLED}
 
 [agents]
 agent_yaml_bucket=${AGENT_YAML_BUCKET}
+executions_bucket=${AGENTIC_EXECUTIONS_BUCKET}
 
 [auth]
 max_failed_attempts=${MAX_FAILED_ATTEMPTS}

--- a/wavefront/server/apps/floware/floware/server.py
+++ b/wavefront/server/apps/floware/floware/server.py
@@ -184,7 +184,7 @@ agents_container = AgentsContainer(
     message_processor_bucket_name=bucket_name,
     api_services_manager=api_services_container.api_service_manager,
     async_agentic_execution_repository=db_repo_container.async_agentic_execution_repository,
-    executions_bucket=config['agents']['agent_yaml_bucket'],
+    executions_bucket=config['agents']['executions_bucket'],
 )
 
 inference_container = InferenceContainer(

--- a/wavefront/server/apps/floware/floware/server.py
+++ b/wavefront/server/apps/floware/floware/server.py
@@ -272,7 +272,9 @@ async def lifespan(app: FastAPI):
             exec_repo=db_repo_container.async_agentic_execution_repository(),
             cache_manager=db_repo_container.cache_manager(),
         )
-        asyncio.create_task(async_agentic_exec_consumer.start())
+        async_agentic_exec_consumer_task = asyncio.create_task(
+            async_agentic_exec_consumer.start()
+        )
 
         # Set app reference in proxy router so new routes can be added dynamically
         proxy_router = api_services_container.proxy_router()
@@ -283,6 +285,14 @@ async def lifespan(app: FastAPI):
 
         # Shutdown code
         scheduler_manager.shutdown()
+        async_agentic_exec_consumer.stop()
+        try:
+            await asyncio.wait_for(async_agentic_exec_consumer_task, timeout=5)
+        except asyncio.TimeoutError:
+            async_agentic_exec_consumer_task.cancel()
+            logger.warning(
+                'AsyncAgenticExecutionResultConsumer did not stop within 5s; cancelled'
+            )
         logger.info('Shutting down application...')
 
     except Exception as e:

--- a/wavefront/server/apps/floware/floware/server.py
+++ b/wavefront/server/apps/floware/floware/server.py
@@ -69,6 +69,10 @@ from agents_module.controllers.workflow_runs import workflow_runs_router
 from agents_module.controllers.workflow_pipeline_controller import (
     workflow_pipeline_router,
 )
+from agents_module.controllers.async_inference_controller import async_router
+from agents_module.services.async_agentic_execution_result_consumer import (
+    AsyncAgenticExecutionResultConsumer,
+)
 from agents_module.agents_container import AgentsContainer
 from inference_module.inference_container import InferenceContainer
 from inference_module.controllers.inference_controller import inference_router
@@ -179,6 +183,8 @@ agents_container = AgentsContainer(
     message_processor_repository=plugins_container.message_processor_repository,
     message_processor_bucket_name=bucket_name,
     api_services_manager=api_services_container.api_service_manager,
+    async_agentic_execution_repository=db_repo_container.async_agentic_execution_repository,
+    executions_bucket=config['agents']['agent_yaml_bucket'],
 )
 
 inference_container = InferenceContainer(
@@ -260,6 +266,13 @@ async def lifespan(app: FastAPI):
                 api_change_processor=api_services_container.api_change_processor(),
             )
         )
+
+        # Start Redis Stream consumer for async execution status updates
+        async_agentic_exec_consumer = AsyncAgenticExecutionResultConsumer(
+            exec_repo=db_repo_container.async_agentic_execution_repository(),
+            cache_manager=db_repo_container.cache_manager(),
+        )
+        asyncio.create_task(async_agentic_exec_consumer.start())
 
         # Set app reference in proxy router so new routes can be added dynamically
         proxy_router = api_services_container.proxy_router()
@@ -380,6 +393,7 @@ app.include_router(product_analysis_router, prefix='/floware')
 app.include_router(agents_router, prefix='/floware')
 app.include_router(namespace_router, prefix='/floware')
 app.include_router(workflows_router, prefix='/floware')
+app.include_router(async_router, prefix='/floware')
 app.include_router(workflow_pipeline_router, prefix='/floware')
 app.include_router(workflow_runs_router, prefix='/floware')
 app.include_router(inference_router, prefix='/floware')

--- a/wavefront/server/background_jobs/celery_worker/celery_worker/celery_app.py
+++ b/wavefront/server/background_jobs/celery_worker/celery_worker/celery_app.py
@@ -1,16 +1,11 @@
-from dotenv import load_dotenv
-
-
-import os
-
 from celery import Celery
 
-load_dotenv()  # load .env before reading env vars
+from celery_worker.env import CELERY_BROKER_URL, CELERY_RESULT_BACKEND
 
 app = Celery('async_executor')
 app.conf.update(
-    broker_url=os.getenv('CELERY_BROKER_URL', 'redis://localhost:6379/0'),
-    result_backend=os.getenv('CELERY_RESULT_BACKEND', 'redis://localhost:6379/1'),
+    broker_url=CELERY_BROKER_URL,
+    result_backend=CELERY_RESULT_BACKEND,
     include=[
         'celery_worker.tasks.agent_task',
         'celery_worker.tasks.workflow_task',

--- a/wavefront/server/background_jobs/celery_worker/celery_worker/celery_app.py
+++ b/wavefront/server/background_jobs/celery_worker/celery_worker/celery_app.py
@@ -1,0 +1,27 @@
+from dotenv import load_dotenv
+
+
+import os
+
+from celery import Celery
+
+load_dotenv()  # load .env before reading env vars
+
+app = Celery('async_executor')
+app.conf.update(
+    broker_url=os.getenv('CELERY_BROKER_URL', 'redis://localhost:6379/0'),
+    result_backend=os.getenv('CELERY_RESULT_BACKEND', 'redis://localhost:6379/1'),
+    include=[
+        'celery_worker.tasks.agent_task',
+        'celery_worker.tasks.workflow_task',
+    ],
+    task_serializer='json',
+    accept_content=['json'],
+    result_serializer='json',
+    timezone='UTC',
+    enable_utc=True,
+    task_acks_late=True,  # Only ack after successful processing
+    task_reject_on_worker_lost=True,  # Re-queue on worker crash
+    worker_prefetch_multiplier=1,  # Fair task distribution
+    task_track_started=True,
+)

--- a/wavefront/server/background_jobs/celery_worker/celery_worker/env.py
+++ b/wavefront/server/background_jobs/celery_worker/celery_worker/env.py
@@ -25,6 +25,7 @@ STREAM_NAME: str = os.getenv(
 # Cloud / storage
 CLOUD_PROVIDER: str = os.environ['CLOUD_PROVIDER']
 AGENT_YAML_BUCKET: str = os.environ['AGENT_YAML_BUCKET']
+AGENTIC_EXECUTIONS_BUCKET: str = os.environ['AGENTIC_EXECUTIONS_BUCKET']
 
 # App
 WORKFLOW_WORKER_TOPIC: str = os.getenv('WORKFLOW_WORKER_TOPIC', '')

--- a/wavefront/server/background_jobs/celery_worker/celery_worker/env.py
+++ b/wavefront/server/background_jobs/celery_worker/celery_worker/env.py
@@ -1,0 +1,38 @@
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# Celery broker / backend
+CELERY_BROKER_URL: str = os.getenv('CELERY_BROKER_URL', 'redis://localhost:6379/0')
+CELERY_RESULT_BACKEND: str = os.getenv(
+    'CELERY_RESULT_BACKEND', 'redis://localhost:6379/1'
+)
+
+# Task retry settings
+try:
+    MAX_RETRIES: int = int(os.getenv('CELERY_TASK_MAX_RETRIES', '0'))
+    RETRY_DELAY: int = int(os.getenv('CELERY_TASK_RETRY_DELAY_SECONDS', '30'))
+except ValueError as e:
+    raise ValueError(f'Invalid integer in retry configuration: {e}') from e
+
+# Redis Stream
+STREAM_NAME: str = os.getenv(
+    'ASYNC_AGENTIC_EXEC_RESULTS_STREAM', 'async_agentic_exec:results'
+)
+
+# Cloud / storage
+CLOUD_PROVIDER: str = os.environ['CLOUD_PROVIDER']
+AGENT_YAML_BUCKET: str = os.environ['AGENT_YAML_BUCKET']
+
+# App
+WORKFLOW_WORKER_TOPIC: str = os.getenv('WORKFLOW_WORKER_TOPIC', '')
+APP_NAME: str = os.getenv('APP_NAME', 'floware')
+
+# Database
+DB_USERNAME: str = os.environ['DB_USERNAME']
+DB_PASSWORD: str = os.environ['DB_PASSWORD']
+DB_HOST: str = os.environ['DB_HOST']
+DB_PORT: str = os.environ['DB_PORT']
+DB_NAME: str = os.environ['DB_NAME']

--- a/wavefront/server/background_jobs/celery_worker/celery_worker/main.py
+++ b/wavefront/server/background_jobs/celery_worker/celery_worker/main.py
@@ -1,0 +1,11 @@
+from dotenv import load_dotenv
+
+
+from celery_worker.celery_app import app  # noqa: E402, F401 — triggers autodiscover
+import celery_worker.tasks.agent_task  # noqa: F401
+import celery_worker.tasks.workflow_task  # noqa: F401
+
+load_dotenv()
+
+if __name__ == '__main__':
+    app.start()

--- a/wavefront/server/background_jobs/celery_worker/celery_worker/tasks/agent_task.py
+++ b/wavefront/server/background_jobs/celery_worker/celery_worker/tasks/agent_task.py
@@ -1,7 +1,6 @@
 import asyncio
 import base64
 import json
-import os
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 from uuid import UUID
@@ -11,13 +10,8 @@ from db_repo_module.models.llm_inference_config import LlmInferenceConfig
 from agents_module.utils.input_processing_utils import process_inference_inputs
 
 from celery_worker.celery_app import app
+from celery_worker.env import MAX_RETRIES, RETRY_DELAY, STREAM_NAME
 from celery_worker.worker_setup import get_services
-
-STREAM_NAME = os.getenv(
-    'ASYNC_AGENTIC_EXEC_RESULTS_STREAM', 'async_agentic_exec:results'
-)
-MAX_RETRIES = int(os.getenv('CELERY_TASK_MAX_RETRIES', '0'))
-RETRY_DELAY = int(os.getenv('CELERY_TASK_RETRY_DELAY_SECONDS', '30'))
 
 
 def _now() -> str:
@@ -111,7 +105,7 @@ async def _run(task, payload: Dict) -> None:
         (
             result,
             exec_time,
-            namespace,
+            _namespace,
         ) = await services.agent_inference.perform_inference_v2(
             agent_id=UUID(payload['entity_id']),
             variables=payload.get('variables') or {},

--- a/wavefront/server/background_jobs/celery_worker/celery_worker/tasks/agent_task.py
+++ b/wavefront/server/background_jobs/celery_worker/celery_worker/tasks/agent_task.py
@@ -1,0 +1,195 @@
+import asyncio
+import base64
+import json
+import os
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from common_module.log.logger import logger
+from db_repo_module.models.llm_inference_config import LlmInferenceConfig
+from agents_module.utils.input_processing_utils import process_inference_inputs
+
+from celery_worker.celery_app import app
+from celery_worker.worker_setup import get_services
+
+STREAM_NAME = os.getenv(
+    'ASYNC_AGENTIC_EXEC_RESULTS_STREAM', 'async_agentic_exec:results'
+)
+MAX_RETRIES = int(os.getenv('CELERY_TASK_MAX_RETRIES', '0'))
+RETRY_DELAY = int(os.getenv('CELERY_TASK_RETRY_DELAY_SECONDS', '30'))
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _build_llm_config(llm_config_dict: Optional[Dict]) -> Optional[LlmInferenceConfig]:
+    if not llm_config_dict:
+        return None
+    return LlmInferenceConfig(**llm_config_dict)
+
+
+def _reconstruct_inputs(payload: Dict, cloud_storage) -> Any:
+    """
+    Rebuild inputs from the clean JSON in the task payload.
+    Stored binary entries are fetched from cloud storage and re-encoded to base64
+    so that process_inference_inputs() can handle them normally.
+    """
+    raw_inputs = payload['inputs']
+
+    if isinstance(raw_inputs, str):
+        return process_inference_inputs(raw_inputs)
+
+    rebuilt: List[Dict] = []
+    for entry in raw_inputs:
+        if not isinstance(entry, dict) or not entry.get('stored'):
+            rebuilt.append(entry)
+            continue
+
+        file_bytes = cloud_storage.read_file(entry['bucket'], entry['key'])
+        b64 = base64.b64encode(file_bytes).decode('utf-8')
+        input_type = entry.get('input_type', 'document')
+        mime_type = entry.get('mime_type')
+        file_name = entry.get('file_name')
+
+        content: Dict = (
+            {'document_base64': b64}
+            if input_type == 'document'
+            else {'image_base64': b64}
+        )
+        if mime_type:
+            content['mime_type'] = mime_type
+        if file_name:
+            content['file_name'] = file_name
+
+        rebuilt.append({'role': 'user', 'content': content})
+
+    return process_inference_inputs(rebuilt)
+
+
+def _save_json(cloud_storage, bucket: str, key: str, data: Any) -> None:
+    cloud_storage.save_small_file(
+        file_content=json.dumps(data, default=str).encode('utf-8'),
+        bucket_name=bucket,
+        key=key,
+        content_type='application/json',
+    )
+
+
+def _build_history(payload: Dict, result: Any, exec_time: float) -> Dict:
+    return {
+        'execution_id': payload['execution_id'],
+        'entity_type': payload['entity_type'],
+        'entity_id': payload['entity_id'],
+        'inputs': payload['inputs'],  # clean inputs with storage key refs
+        'variables': payload.get('variables') or {},
+        'output': result,
+        'execution_time_seconds': round(exec_time, 3),
+    }
+
+
+async def _run(task, payload: Dict) -> None:
+    services = get_services()
+    execution_id = payload['execution_id']
+
+    # Signal in_progress — floware consumer updates DB
+    services.cache.xadd(
+        STREAM_NAME,
+        {
+            'execution_id': execution_id,
+            'status': 'in_progress',
+            'started_at': _now(),
+            'error': '',
+        },
+    )
+
+    try:
+        inputs = _reconstruct_inputs(payload, services.cloud_storage)
+        llm_config = _build_llm_config(payload.get('llm_config'))
+
+        (
+            result,
+            exec_time,
+            namespace,
+        ) = await services.agent_inference.perform_inference_v2(
+            agent_id=UUID(payload['entity_id']),
+            variables=payload.get('variables') or {},
+            inputs=inputs if isinstance(inputs, list) else [inputs],
+            llm_config=llm_config,
+            output_json_enabled=payload.get('output_json_enabled', True),
+            access_token=payload.get('access_token'),
+            app_key=payload.get('app_key'),
+        )
+
+        final_result = result[-1].content if isinstance(result, list) else result
+
+        output_key = f"{payload['output_prefix']}output.json"
+        history_key = f"{payload['output_prefix']}history.json"
+        bucket = payload['execution_bucket']
+
+        _save_json(
+            services.cloud_storage,
+            bucket,
+            output_key,
+            {
+                'result': final_result,
+                'execution_time_seconds': round(exec_time, 3),
+            },
+        )
+        _save_json(
+            services.cloud_storage,
+            bucket,
+            history_key,
+            _build_history(payload, final_result, exec_time),
+        )
+
+        # Signal completed — floware consumer updates DB
+        services.cache.xadd(
+            STREAM_NAME,
+            {
+                'execution_id': execution_id,
+                'status': 'completed',
+                'output_file': output_key,
+                'history_file': history_key,
+                'input_bucket': bucket,
+                'completed_at': _now(),
+                'error': '',
+            },
+        )
+        logger.info(f'Agent execution completed: {execution_id} in {exec_time:.2f}s')
+
+    except Exception as exc:
+        error_msg = str(exc)
+        logger.error(f'Agent execution failed: {execution_id} — {error_msg}')
+
+        # Signal failed — floware consumer updates DB
+        services.cache.xadd(
+            STREAM_NAME,
+            {
+                'execution_id': execution_id,
+                'status': 'failed',
+                'error': error_msg,
+                'completed_at': _now(),
+            },
+        )
+        raise  # triggers Celery retry if MAX_RETRIES > 0
+
+
+@app.task(
+    bind=True,
+    name='celery_worker.tasks.agent_task.execute_agent_task',
+    max_retries=MAX_RETRIES,
+    default_retry_delay=RETRY_DELAY,
+)
+def execute_agent_task(self, payload: Dict) -> None:
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(_run(self, payload))
+    finally:
+        # Drain any pending tasks (e.g. HTTP client aclose() from google.genai)
+        # before destroying the loop to suppress "Task was destroyed but pending" warnings
+        pending = asyncio.all_tasks(loop)
+        if pending:
+            loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+        loop.close()

--- a/wavefront/server/background_jobs/celery_worker/celery_worker/tasks/workflow_task.py
+++ b/wavefront/server/background_jobs/celery_worker/celery_worker/tasks/workflow_task.py
@@ -1,10 +1,10 @@
 import asyncio
-import os
 from typing import Dict
 
 from common_module.log.logger import logger
 
 from celery_worker.celery_app import app
+from celery_worker.env import MAX_RETRIES, RETRY_DELAY, STREAM_NAME
 from celery_worker.tasks.agent_task import (
     _build_history,
     _now,
@@ -12,12 +12,6 @@ from celery_worker.tasks.agent_task import (
     _save_json,
 )
 from celery_worker.worker_setup import get_services
-
-STREAM_NAME = os.getenv(
-    'ASYNC_AGENTIC_EXEC_RESULTS_STREAM', 'async_agentic_exec:results'
-)
-MAX_RETRIES = int(os.getenv('CELERY_TASK_MAX_RETRIES', '0'))
-RETRY_DELAY = int(os.getenv('CELERY_TASK_RETRY_DELAY_SECONDS', '30'))
 
 
 async def _run(task, payload: Dict) -> None:

--- a/wavefront/server/background_jobs/celery_worker/celery_worker/tasks/workflow_task.py
+++ b/wavefront/server/background_jobs/celery_worker/celery_worker/tasks/workflow_task.py
@@ -1,0 +1,122 @@
+import asyncio
+import os
+from typing import Dict
+
+from common_module.log.logger import logger
+
+from celery_worker.celery_app import app
+from celery_worker.tasks.agent_task import (
+    _build_history,
+    _now,
+    _reconstruct_inputs,
+    _save_json,
+)
+from celery_worker.worker_setup import get_services
+
+STREAM_NAME = os.getenv(
+    'ASYNC_AGENTIC_EXEC_RESULTS_STREAM', 'async_agentic_exec:results'
+)
+MAX_RETRIES = int(os.getenv('CELERY_TASK_MAX_RETRIES', '0'))
+RETRY_DELAY = int(os.getenv('CELERY_TASK_RETRY_DELAY_SECONDS', '30'))
+
+
+async def _run(task, payload: Dict) -> None:
+    services = get_services()
+    execution_id = payload['execution_id']
+
+    # Signal in_progress — floware consumer updates DB
+    services.cache.xadd(
+        STREAM_NAME,
+        {
+            'execution_id': execution_id,
+            'status': 'in_progress',
+            'started_at': _now(),
+            'error': '',
+        },
+    )
+
+    try:
+        inputs = _reconstruct_inputs(payload, services.cloud_storage)
+
+        result, exec_time = await services.workflow_inference.perform_inference_v2(
+            workflow_data={
+                'id': payload['entity_id'],
+                'name': payload['workflow_name'],
+                'namespace': payload['namespace'],
+            },
+            variables=payload.get('variables') or {},
+            inputs=inputs if isinstance(inputs, list) else [inputs],
+            output_json_enabled=payload.get('output_json_enabled', False),
+            event_callback=None,
+            events_filter=None,
+            access_token=payload.get('access_token'),
+            app_key=payload.get('app_key'),
+        )
+
+        output_key = f"{payload['output_prefix']}output.json"
+        history_key = f"{payload['output_prefix']}history.json"
+        bucket = payload['execution_bucket']
+
+        _save_json(
+            services.cloud_storage,
+            bucket,
+            output_key,
+            {
+                'result': result,
+                'execution_time_seconds': round(exec_time, 3),
+            },
+        )
+        _save_json(
+            services.cloud_storage,
+            bucket,
+            history_key,
+            _build_history(payload, result, exec_time),
+        )
+
+        # Signal completed — floware consumer updates DB
+        services.cache.xadd(
+            STREAM_NAME,
+            {
+                'execution_id': execution_id,
+                'status': 'completed',
+                'output_file': output_key,
+                'history_file': history_key,
+                'input_bucket': bucket,
+                'completed_at': _now(),
+                'error': '',
+            },
+        )
+        logger.info(f'Workflow execution completed: {execution_id} in {exec_time:.2f}s')
+
+    except Exception as exc:
+        error_msg = str(exc)
+        logger.error(f'Workflow execution failed: {execution_id} — {error_msg}')
+
+        # Signal failed — floware consumer updates DB
+        services.cache.xadd(
+            STREAM_NAME,
+            {
+                'execution_id': execution_id,
+                'status': 'failed',
+                'error': error_msg,
+                'completed_at': _now(),
+            },
+        )
+        raise  # triggers Celery retry if MAX_RETRIES > 0
+
+
+@app.task(
+    bind=True,
+    name='celery_worker.tasks.workflow_task.execute_workflow_task',
+    max_retries=MAX_RETRIES,
+    default_retry_delay=RETRY_DELAY,
+)
+def execute_workflow_task(self, payload: Dict) -> None:
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(_run(self, payload))
+    finally:
+        pending = asyncio.all_tasks(loop)
+        if pending:
+            loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+        loop.close()

--- a/wavefront/server/background_jobs/celery_worker/celery_worker/worker_setup.py
+++ b/wavefront/server/background_jobs/celery_worker/celery_worker/worker_setup.py
@@ -27,6 +27,7 @@ from tools_module.tools_container import ToolsContainer
 
 from celery_worker.env import (
     AGENT_YAML_BUCKET,
+    AGENTIC_EXECUTIONS_BUCKET,
     APP_NAME,
     CLOUD_PROVIDER,
     DB_HOST,
@@ -127,7 +128,7 @@ def get_services() -> WorkerServices:
             message_processor_bucket_name=bucket_name,
             api_services_manager=api_services_container.api_service_manager,
             async_agentic_execution_repository=db_repo_container.async_agentic_execution_repository,
-            executions_bucket=bucket_name,
+            executions_bucket=AGENTIC_EXECUTIONS_BUCKET,
         )
 
         # Inject config values from env vars so services like AgentCrudService
@@ -149,7 +150,7 @@ def get_services() -> WorkerServices:
             workflow_inference=agents_container.workflow_inference_service(),
             cloud_storage=common_container.cloud_storage_manager(),
             cache=cache,
-            execution_bucket=bucket_name,
+            execution_bucket=AGENTIC_EXECUTIONS_BUCKET,
         )
 
     return _services

--- a/wavefront/server/background_jobs/celery_worker/celery_worker/worker_setup.py
+++ b/wavefront/server/background_jobs/celery_worker/celery_worker/worker_setup.py
@@ -4,9 +4,6 @@ No DB connection owned by the worker — status updates go through Redis Streams
 DB credentials are read from env vars so config.ini is not required.
 """
 
-from dotenv import load_dotenv
-
-import os
 import threading
 from dataclasses import dataclass
 from typing import Optional
@@ -28,7 +25,17 @@ from flo_cloud.cloud_storage import CloudStorageManager
 from plugins_module.plugins_container import PluginsContainer
 from tools_module.tools_container import ToolsContainer
 
-load_dotenv()
+from celery_worker.env import (
+    AGENT_YAML_BUCKET,
+    APP_NAME,
+    CLOUD_PROVIDER,
+    DB_HOST,
+    DB_NAME,
+    DB_PASSWORD,
+    DB_PORT,
+    DB_USERNAME,
+    WORKFLOW_WORKER_TOPIC,
+)
 
 
 @dataclass
@@ -47,11 +54,11 @@ _services: Optional[WorkerServices] = None
 def _build_db_client() -> DatabaseClient:
     """Build DatabaseClient directly from env vars — no config.ini needed."""
     db_config = DatabaseConfig(
-        username=os.environ['DB_USERNAME'],
-        password=os.environ['DB_PASSWORD'],
-        host=os.environ['DB_HOST'],
-        port=os.environ['DB_PORT'],
-        db_name=os.environ['DB_NAME'],
+        username=DB_USERNAME,
+        password=DB_PASSWORD,
+        host=DB_HOST,
+        port=DB_PORT,
+        db_name=DB_NAME,
     )
     return DatabaseClient(db_config)
 
@@ -74,17 +81,9 @@ def get_services() -> WorkerServices:
             cache_manager=db_repo_container.cache_manager
         )
 
-        import google.auth
-
-        _, project = google.auth.default()
-        print(
-            f"[DEBUG] ADC project: {project}, GOOGLE_CLOUD_PROJECT env: {os.getenv('GOOGLE_CLOUD_PROJECT')}"
-        )
-
         # Override cloud storage manager with env-var-based provider
-        cloud_provider = os.environ['CLOUD_PROVIDER']
         common_container.cloud_storage_manager.override(
-            providers.Object(CloudStorageManager(provider=cloud_provider))
+            providers.Object(CloudStorageManager(provider=CLOUD_PROVIDER))
         )
 
         api_services_container: ApiServicesContainer = create_api_services_container(
@@ -102,7 +101,7 @@ def get_services() -> WorkerServices:
             cache_manager=db_repo_container.cache_manager,
         )
 
-        bucket_name = os.environ['AGENT_YAML_BUCKET']
+        bucket_name = AGENT_YAML_BUCKET
 
         tools_container = ToolsContainer(
             datasource_repository=db_repo_container.datasource_repository,
@@ -136,14 +135,14 @@ def get_services() -> WorkerServices:
         agents_container.config.from_dict(
             {
                 'agents': {'agent_yaml_bucket': bucket_name},
-                'cloud_config': {'cloud_provider': os.getenv('CLOUD_PROVIDER', 'aws')},
-                'workflow': {'worker_topic': os.getenv('WORKFLOW_WORKER_TOPIC', '')},
+                'cloud_config': {'cloud_provider': CLOUD_PROVIDER},
+                'workflow': {'worker_topic': WORKFLOW_WORKER_TOPIC},
             }
         )
 
         # Must use the same namespace as the floware app so stream keys match
         # floware's CacheManager uses config.env_config.app_name as its namespace
-        cache = CacheManager(namespace=os.getenv('APP_NAME', 'floware'))
+        cache = CacheManager(namespace=APP_NAME)
 
         _services = WorkerServices(
             agent_inference=agents_container.agent_inference_service(),

--- a/wavefront/server/background_jobs/celery_worker/celery_worker/worker_setup.py
+++ b/wavefront/server/background_jobs/celery_worker/celery_worker/worker_setup.py
@@ -1,0 +1,156 @@
+"""
+Initializes all services once per worker process.
+No DB connection owned by the worker — status updates go through Redis Streams.
+DB credentials are read from env vars so config.ini is not required.
+"""
+
+from dotenv import load_dotenv
+
+import os
+import threading
+from dataclasses import dataclass
+from typing import Optional
+
+from dependency_injector import providers
+
+from api_services_module.api_services_container import (
+    ApiServicesContainer,
+    create_api_services_container,
+)
+from agents_module.agents_container import AgentsContainer
+from agents_module.services.agent_inference_service import AgentInferenceService
+from agents_module.services.workflow_inference_service import WorkflowInferenceService
+from common_module.common_container import CommonContainer
+from db_repo_module.cache.cache_manager import CacheManager
+from db_repo_module.database.connection import DatabaseConfig, DatabaseClient
+from db_repo_module.db_repo_container import DatabaseModuleContainer
+from flo_cloud.cloud_storage import CloudStorageManager
+from plugins_module.plugins_container import PluginsContainer
+from tools_module.tools_container import ToolsContainer
+
+load_dotenv()
+
+
+@dataclass
+class WorkerServices:
+    agent_inference: AgentInferenceService
+    workflow_inference: WorkflowInferenceService
+    cloud_storage: CloudStorageManager
+    cache: CacheManager
+    execution_bucket: str
+
+
+_lock = threading.Lock()
+_services: Optional[WorkerServices] = None
+
+
+def _build_db_client() -> DatabaseClient:
+    """Build DatabaseClient directly from env vars — no config.ini needed."""
+    db_config = DatabaseConfig(
+        username=os.environ['DB_USERNAME'],
+        password=os.environ['DB_PASSWORD'],
+        host=os.environ['DB_HOST'],
+        port=os.environ['DB_PORT'],
+        db_name=os.environ['DB_NAME'],
+    )
+    return DatabaseClient(db_config)
+
+
+def get_services() -> WorkerServices:
+    global _services
+    if _services is not None:
+        return _services
+
+    with _lock:
+        if _services is not None:
+            return _services
+
+        # Build DB client from env vars and override the container's singleton
+        db_client = _build_db_client()
+        db_repo_container = DatabaseModuleContainer()
+        db_repo_container.db_client.override(providers.Object(db_client))
+
+        common_container = CommonContainer(
+            cache_manager=db_repo_container.cache_manager
+        )
+
+        import google.auth
+
+        _, project = google.auth.default()
+        print(
+            f"[DEBUG] ADC project: {project}, GOOGLE_CLOUD_PROJECT env: {os.getenv('GOOGLE_CLOUD_PROJECT')}"
+        )
+
+        # Override cloud storage manager with env-var-based provider
+        cloud_provider = os.environ['CLOUD_PROVIDER']
+        common_container.cloud_storage_manager.override(
+            providers.Object(CloudStorageManager(provider=cloud_provider))
+        )
+
+        api_services_container: ApiServicesContainer = create_api_services_container(
+            api_service_repository=db_repo_container.api_services_repository,
+            cloud_storage_manager=common_container.cloud_storage_manager,
+            db_client=db_repo_container.db_client,
+            cache_manager=db_repo_container.cache_manager,
+            response_formatter=common_container.response_formatter,
+        )
+
+        plugins_container = PluginsContainer(
+            db_client=db_repo_container.db_client,
+            cloud_storage_manager=common_container.cloud_storage_manager,
+            dynamic_query_repository=db_repo_container.dynamic_query_repository,
+            cache_manager=db_repo_container.cache_manager,
+        )
+
+        bucket_name = os.environ['AGENT_YAML_BUCKET']
+
+        tools_container = ToolsContainer(
+            datasource_repository=db_repo_container.datasource_repository,
+            knowledge_base_repository=db_repo_container.knowledge_base_repository,
+            knowledge_base_inference_repository=db_repo_container.knowledge_base_inference_repository,
+            message_processor_repository=plugins_container.message_processor_repository,
+            api_services_manager=api_services_container.api_service_manager,
+            cloud_storage_manager=common_container.cloud_storage_manager,
+            message_processor_bucket_name=bucket_name,
+        )
+
+        agents_container = AgentsContainer(
+            db_client=db_repo_container.db_client,
+            cloud_storage_manager=common_container.cloud_storage_manager,
+            cache_manager=db_repo_container.cache_manager,
+            tool_loader=tools_container.tool_loader,
+            workflow_pipeline_repository=db_repo_container.workflow_pipeline_repository,
+            workflow_runs_repository=db_repo_container.workflow_runs_repository,
+            namespace_repository=db_repo_container.namespace_repository,
+            agent_repository=db_repo_container.agent_repository,
+            workflow_repository=db_repo_container.workflow_repository,
+            message_processor_repository=plugins_container.message_processor_repository,
+            message_processor_bucket_name=bucket_name,
+            api_services_manager=api_services_container.api_service_manager,
+            async_agentic_execution_repository=db_repo_container.async_agentic_execution_repository,
+            executions_bucket=bucket_name,
+        )
+
+        # Inject config values from env vars so services like AgentCrudService
+        # get the correct bucket_name via config.agents.agent_yaml_bucket
+        agents_container.config.from_dict(
+            {
+                'agents': {'agent_yaml_bucket': bucket_name},
+                'cloud_config': {'cloud_provider': os.getenv('CLOUD_PROVIDER', 'aws')},
+                'workflow': {'worker_topic': os.getenv('WORKFLOW_WORKER_TOPIC', '')},
+            }
+        )
+
+        # Must use the same namespace as the floware app so stream keys match
+        # floware's CacheManager uses config.env_config.app_name as its namespace
+        cache = CacheManager(namespace=os.getenv('APP_NAME', 'floware'))
+
+        _services = WorkerServices(
+            agent_inference=agents_container.agent_inference_service(),
+            workflow_inference=agents_container.workflow_inference_service(),
+            cloud_storage=common_container.cloud_storage_manager(),
+            cache=cache,
+            execution_bucket=bucket_name,
+        )
+
+    return _services

--- a/wavefront/server/background_jobs/celery_worker/pyproject.toml
+++ b/wavefront/server/background_jobs/celery_worker/pyproject.toml
@@ -1,0 +1,39 @@
+[project]
+name = "celery-worker"
+version = "0.1.0"
+description = "Async agent and workflow execution via Celery"
+authors = [
+    { name = "rootflo engineering", email = "engineering@rootflo.ai" }
+]
+requires-python = ">=3.11"
+
+dependencies = [
+    "agents-module",
+    "db-repo-module",
+    "flo-cloud",
+    "flo-utils",
+    "tools-module",
+    "api-services-module",
+    "common-module",
+    "celery[redis]>=5.4.0,<6.0.0",
+    "python-dotenv>=1.1.0,<2.0.0",
+]
+
+[tool.uv.sources]
+agents-module       = { workspace = true }
+db-repo-module      = { workspace = true }
+flo-cloud           = { workspace = true }
+flo-utils           = { workspace = true }
+tools-module        = { workspace = true }
+api-services-module = { workspace = true }
+common-module       = { workspace = true }
+
+[tool.uv]
+package = true
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["celery_worker"]

--- a/wavefront/server/modules/agents_module/agents_module/agents_container.py
+++ b/wavefront/server/modules/agents_module/agents_module/agents_container.py
@@ -2,6 +2,9 @@ from dependency_injector import containers
 from dependency_injector import providers
 from agents_module.services.agent_inference_service import AgentInferenceService
 from agents_module.services.agent_crud_service import AgentCrudService
+from agents_module.services.async_agentic_execution_service import (
+    AsyncAgenticExecutionService,
+)
 from agents_module.services.namespace_service import NamespaceService
 from agents_module.services.workflow_crud_service import WorkflowCrudService
 from agents_module.services.workflow_inference_service import WorkflowInferenceService
@@ -33,6 +36,10 @@ class AgentsContainer(containers.DeclarativeContainer):
     message_processor_bucket_name = providers.Dependency()
 
     api_services_manager = providers.Dependency()
+
+    async_agentic_execution_repository = providers.Dependency()
+
+    executions_bucket = providers.Dependency()
 
     namespace_service = providers.Singleton(
         NamespaceService,
@@ -82,6 +89,14 @@ class AgentsContainer(containers.DeclarativeContainer):
         bucket_name=config.agents.agent_yaml_bucket,
         agent_crud_service=agent_crud_service,
         tool_loader=tool_loader,
+    )
+
+    async_agentic_execution_service = providers.Singleton(
+        AsyncAgenticExecutionService,
+        async_agentic_execution_repository=async_agentic_execution_repository,
+        cloud_storage_manager=cloud_storage_manager,
+        cache_manager=cache_manager,
+        executions_bucket=executions_bucket,
     )
 
     message_queue_manager = providers.Singleton(

--- a/wavefront/server/modules/agents_module/agents_module/controllers/async_inference_controller.py
+++ b/wavefront/server/modules/agents_module/agents_module/controllers/async_inference_controller.py
@@ -67,15 +67,21 @@ async def async_agent_inference(
             'base_url': getattr(config_obj, 'base_url', None),
         }
 
-    result = await async_agentic_execution_service.create_and_enqueue_agent(
-        agent_id=agent_id,
-        inputs=payload.inputs,
-        variables=payload.variables,
-        output_json_enabled=payload.output_json_enabled,
-        access_token=access_token,
-        app_key=app_key,
-        llm_config=llm_config,
-    )
+    try:
+        result = await async_agentic_execution_service.create_and_enqueue_agent(
+            agent_id=agent_id,
+            inputs=payload.inputs,
+            variables=payload.variables,
+            output_json_enabled=payload.output_json_enabled,
+            access_token=access_token,
+            app_key=app_key,
+            llm_config=llm_config,
+        )
+    except ValueError as e:
+        return JSONResponse(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            content=response_formatter.buildErrorResponse(str(e)),
+        )
 
     logger.info(f'Agent execution enqueued: {result.execution_id}')
     return JSONResponse(
@@ -119,16 +125,22 @@ async def async_workflow_inference(
             content=response_formatter.buildErrorResponse(str(e)),
         )
 
-    result = await async_agentic_execution_service.create_and_enqueue_workflow(
-        workflow_id=workflow_id,
-        workflow_name=workflow_data['name'],
-        namespace=workflow_data['namespace'],
-        inputs=payload.inputs,
-        variables=payload.variables,
-        output_json_enabled=payload.output_json_enabled,
-        access_token=access_token,
-        app_key=app_key,
-    )
+    try:
+        result = await async_agentic_execution_service.create_and_enqueue_workflow(
+            workflow_id=workflow_id,
+            workflow_name=workflow_data['name'],
+            namespace=workflow_data['namespace'],
+            inputs=payload.inputs,
+            variables=payload.variables,
+            output_json_enabled=payload.output_json_enabled,
+            access_token=access_token,
+            app_key=app_key,
+        )
+    except ValueError as e:
+        return JSONResponse(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            content=response_formatter.buildErrorResponse(str(e)),
+        )
 
     logger.info(f'Workflow execution enqueued: {result.execution_id}')
     return JSONResponse(

--- a/wavefront/server/modules/agents_module/agents_module/controllers/async_inference_controller.py
+++ b/wavefront/server/modules/agents_module/agents_module/controllers/async_inference_controller.py
@@ -16,7 +16,6 @@ from agents_module.services.workflow_crud_service import WorkflowCrudService
 from agents_module.models.agent_schemas import AgentInferenceRequest
 from agents_module.models.workflow_schemas import WorkflowInferenceRequest
 from agents_module.utils.auth_utils import extract_auth_credentials
-from db_repo_module.models.llm_inference_config import LlmInferenceConfig
 from llm_inference_config_module.container import LlmInferenceConfigContainer
 from llm_inference_config_module.services.llm_inference_config_service import (
     LlmInferenceConfigService,
@@ -59,13 +58,7 @@ async def async_agent_inference(
                     f'LLM inference configuration not found: {payload.llm_inference_config_id}'
                 ),
             )
-        config_obj = LlmInferenceConfig(**llm_config_dict)
-        llm_config = {
-            'type': config_obj.type,
-            'llm_model': config_obj.llm_model,
-            'api_key': config_obj.api_key,
-            'base_url': getattr(config_obj, 'base_url', None),
-        }
+        llm_config = llm_config_dict
 
     try:
         result = await async_agentic_execution_service.create_and_enqueue_agent(

--- a/wavefront/server/modules/agents_module/agents_module/controllers/async_inference_controller.py
+++ b/wavefront/server/modules/agents_module/agents_module/controllers/async_inference_controller.py
@@ -1,0 +1,217 @@
+from uuid import UUID
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query, Request, status
+from fastapi.responses import JSONResponse
+from dependency_injector.wiring import inject, Provide
+
+from common_module.log.logger import logger
+from common_module.response_formatter import ResponseFormatter
+from common_module.common_container import CommonContainer
+from agents_module.agents_container import AgentsContainer
+from agents_module.services.async_agentic_execution_service import (
+    AsyncAgenticExecutionService,
+)
+from agents_module.services.workflow_crud_service import WorkflowCrudService
+from agents_module.models.agent_schemas import AgentInferenceRequest
+from agents_module.models.workflow_schemas import WorkflowInferenceRequest
+from agents_module.utils.auth_utils import extract_auth_credentials
+from db_repo_module.models.llm_inference_config import LlmInferenceConfig
+from llm_inference_config_module.container import LlmInferenceConfigContainer
+from llm_inference_config_module.services.llm_inference_config_service import (
+    LlmInferenceConfigService,
+)
+
+async_router = APIRouter()
+
+
+@async_router.post(
+    '/v3/agents/{agent_id}/inference', status_code=status.HTTP_202_ACCEPTED
+)
+@inject
+async def async_agent_inference(
+    request: Request,
+    agent_id: UUID,
+    payload: AgentInferenceRequest,
+    async_agentic_execution_service: AsyncAgenticExecutionService = Depends(
+        Provide[AgentsContainer.async_agentic_execution_service]
+    ),
+    llm_inference_config_service: LlmInferenceConfigService = Depends(
+        Provide[LlmInferenceConfigContainer.llm_inference_config_service]
+    ),
+    response_formatter: ResponseFormatter = Depends(
+        Provide[CommonContainer.response_formatter]
+    ),
+):
+    logger.info(f'Async agent inference requested for agent_id: {agent_id}')
+
+    access_token, app_key = extract_auth_credentials(request)
+
+    llm_config: Optional[dict] = None
+    if payload.llm_inference_config_id:
+        llm_config_dict = await llm_inference_config_service.get_config(
+            payload.llm_inference_config_id
+        )
+        if not llm_config_dict:
+            return JSONResponse(
+                status_code=status.HTTP_404_NOT_FOUND,
+                content=response_formatter.buildErrorResponse(
+                    f'LLM inference configuration not found: {payload.llm_inference_config_id}'
+                ),
+            )
+        config_obj = LlmInferenceConfig(**llm_config_dict)
+        llm_config = {
+            'type': config_obj.type,
+            'llm_model': config_obj.llm_model,
+            'api_key': config_obj.api_key,
+            'base_url': getattr(config_obj, 'base_url', None),
+        }
+
+    result = await async_agentic_execution_service.create_and_enqueue_agent(
+        agent_id=agent_id,
+        inputs=payload.inputs,
+        variables=payload.variables,
+        output_json_enabled=payload.output_json_enabled,
+        access_token=access_token,
+        app_key=app_key,
+        llm_config=llm_config,
+    )
+
+    logger.info(f'Agent execution enqueued: {result.execution_id}')
+    return JSONResponse(
+        status_code=status.HTTP_202_ACCEPTED,
+        content=response_formatter.buildSuccessResponse(
+            {
+                'message': 'Agent inference queued successfully',
+                'data': result.model_dump(mode='json'),
+            }
+        ),
+    )
+
+
+@async_router.post(
+    '/v3/workflows/{workflow_id}/inference', status_code=status.HTTP_202_ACCEPTED
+)
+@inject
+async def async_workflow_inference(
+    request: Request,
+    workflow_id: UUID,
+    payload: WorkflowInferenceRequest,
+    async_agentic_execution_service: AsyncAgenticExecutionService = Depends(
+        Provide[AgentsContainer.async_agentic_execution_service]
+    ),
+    workflow_crud_service: WorkflowCrudService = Depends(
+        Provide[AgentsContainer.workflow_crud_service]
+    ),
+    response_formatter: ResponseFormatter = Depends(
+        Provide[CommonContainer.response_formatter]
+    ),
+):
+    logger.info(f'Async workflow inference requested for workflow_id: {workflow_id}')
+
+    access_token, app_key = extract_auth_credentials(request)
+
+    try:
+        workflow_data = await workflow_crud_service.get_workflow(workflow_id)
+    except ValueError as e:
+        return JSONResponse(
+            status_code=status.HTTP_404_NOT_FOUND,
+            content=response_formatter.buildErrorResponse(str(e)),
+        )
+
+    result = await async_agentic_execution_service.create_and_enqueue_workflow(
+        workflow_id=workflow_id,
+        workflow_name=workflow_data['name'],
+        namespace=workflow_data['namespace'],
+        inputs=payload.inputs,
+        variables=payload.variables,
+        output_json_enabled=payload.output_json_enabled,
+        access_token=access_token,
+        app_key=app_key,
+    )
+
+    logger.info(f'Workflow execution enqueued: {result.execution_id}')
+    return JSONResponse(
+        status_code=status.HTTP_202_ACCEPTED,
+        content=response_formatter.buildSuccessResponse(
+            {
+                'message': 'Workflow inference queued successfully',
+                'data': result.model_dump(mode='json'),
+            }
+        ),
+    )
+
+
+@async_router.get('/v1/agentic-executions/{execution_id}')
+@inject
+async def get_execution_status(
+    execution_id: UUID,
+    async_agentic_execution_service: AsyncAgenticExecutionService = Depends(
+        Provide[AgentsContainer.async_agentic_execution_service]
+    ),
+    response_formatter: ResponseFormatter = Depends(
+        Provide[CommonContainer.response_formatter]
+    ),
+):
+    try:
+        result = await async_agentic_execution_service.get_execution_status(
+            execution_id
+        )
+    except ValueError as e:
+        return JSONResponse(
+            status_code=status.HTTP_404_NOT_FOUND,
+            content=response_formatter.buildErrorResponse(str(e)),
+        )
+
+    return JSONResponse(
+        status_code=status.HTTP_200_OK,
+        content=response_formatter.buildSuccessResponse(
+            {
+                'message': 'Execution status retrieved successfully',
+                'data': result.model_dump(mode='json'),
+            }
+        ),
+    )
+
+
+@async_router.get('/v1/agentic-executions')
+@inject
+async def list_executions(
+    entity_id: Optional[UUID] = Query(
+        None, description='Filter by agent or workflow UUID'
+    ),
+    entity_type: Optional[str] = Query(
+        None, description='Filter by entity type: agent or workflow'
+    ),
+    execution_status: Optional[str] = Query(
+        None, alias='status', description='Filter by status'
+    ),
+    offset: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=200),
+    async_agentic_execution_service: AsyncAgenticExecutionService = Depends(
+        Provide[AgentsContainer.async_agentic_execution_service]
+    ),
+    response_formatter: ResponseFormatter = Depends(
+        Provide[CommonContainer.response_formatter]
+    ),
+):
+    results = await async_agentic_execution_service.list_executions(
+        entity_id=entity_id,
+        entity_type=entity_type,
+        status=execution_status,
+        offset=offset,
+        limit=limit,
+    )
+
+    return JSONResponse(
+        status_code=status.HTTP_200_OK,
+        content=response_formatter.buildSuccessResponse(
+            {
+                'message': 'Executions retrieved successfully',
+                'data': {
+                    'executions': [r.model_dump(mode='json') for r in results],
+                    'count': len(results),
+                },
+            }
+        ),
+    )

--- a/wavefront/server/modules/agents_module/agents_module/models/async_agentic_execution_schemas.py
+++ b/wavefront/server/modules/agents_module/agents_module/models/async_agentic_execution_schemas.py
@@ -1,0 +1,28 @@
+import uuid
+from datetime import datetime
+from typing import Any, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class AsyncInferenceResponse(BaseModel):
+    execution_id: uuid.UUID
+    status: str = Field(default='pending')
+    entity_type: str
+    entity_id: uuid.UUID
+    status_url: str
+
+
+class AgenticExecutionStatusResponse(BaseModel):
+    id: uuid.UUID
+    entity_type: str
+    entity_id: uuid.UUID
+    celery_task_id: Optional[str] = None
+    status: str
+    error: Optional[str] = None
+    input_files: Optional[List[Any]] = None
+    output_url: Optional[str] = None
+    history_url: Optional[str] = None
+    started_at: Optional[datetime] = None
+    completed_at: Optional[datetime] = None
+    created_at: datetime

--- a/wavefront/server/modules/agents_module/agents_module/services/async_agentic_execution_result_consumer.py
+++ b/wavefront/server/modules/agents_module/agents_module/services/async_agentic_execution_result_consumer.py
@@ -49,7 +49,10 @@ class AsyncAgenticExecutionResultConsumer:
         """Entry point — call as asyncio.create_task(consumer.start())."""
         self._running = True
 
-        # Create consumer group — idempotent, id='0' re-reads pending msgs on restart
+        # Create consumer group — idempotent. id='0' only sets the initial cursor
+        # when the group is first created; subsequent calls are no-ops (BUSYGROUP
+        # silently ignored). PEL entries from a previous run are NOT auto-redelivered
+        # by this call — a separate XAUTOCLAIM/XCLAIM pass would be needed for that.
         self._cache.xgroup_create(_STREAM, _GROUP, id='0', mkstream=True)
         logger.info(
             f'AsyncAgenticExecutionResultConsumer started — stream={_STREAM}, '
@@ -77,7 +80,7 @@ class AsyncAgenticExecutionResultConsumer:
                         except Exception as e:
                             logger.error(
                                 f'Failed to process stream message {msg_id}: {e}. '
-                                'Message will be redelivered on next consumer restart.'
+                                'Message remains in PEL until a claim/drain runs.'
                             )
 
             except Exception as e:

--- a/wavefront/server/modules/agents_module/agents_module/services/async_agentic_execution_result_consumer.py
+++ b/wavefront/server/modules/agents_module/agents_module/services/async_agentic_execution_result_consumer.py
@@ -1,0 +1,153 @@
+import asyncio
+import json
+import os
+import socket
+from datetime import datetime
+from typing import Optional
+from uuid import UUID
+
+from common_module.log.logger import logger
+from db_repo_module.cache.cache_manager import CacheManager
+from db_repo_module.repositories.sql_alchemy_repository import SQLAlchemyRepository
+from db_repo_module.models.async_agentic_execution import AsyncAgenticExecution
+
+_STREAM = os.getenv('ASYNC_AGENTIC_EXEC_RESULTS_STREAM', 'async_agentic_exec:results')
+_GROUP = os.getenv('ASYNC_AGENTIC_EXEC_CONSUMER_GROUP', 'floware-agentic-consumers')
+_CONSUMER = f'floware-{socket.gethostname()}'
+_POLL_COUNT = 10
+_BLOCK_MS = 1000
+
+_STATUS_CACHE_TTL_TERMINAL = 3600
+_STATUS_CACHE_KEY_PREFIX = 'async_agentic_exec:status'
+
+
+class AsyncAgenticExecutionResultConsumer:
+    """
+    Background async task that runs inside the floware FastAPI app.
+    Reads execution result events from a Redis Stream and writes them to DB.
+    This is the only component that updates async_agentic_executions after the
+    initial 'pending' record is created by AsyncAgenticExecutionService.
+
+    Lifecycle:
+        consumer = AsyncAgenticExecutionResultConsumer(exec_repo, cache_manager)
+        task = asyncio.create_task(consumer.start())   # in app lifespan
+        # on shutdown:
+        consumer.stop()
+        await task
+    """
+
+    def __init__(
+        self,
+        exec_repo: SQLAlchemyRepository[AsyncAgenticExecution],
+        cache_manager: CacheManager,
+    ):
+        self._repo = exec_repo
+        self._cache = cache_manager
+        self._running = False
+
+    async def start(self) -> None:
+        """Entry point — call as asyncio.create_task(consumer.start())."""
+        self._running = True
+
+        # Create consumer group — idempotent, id='0' re-reads pending msgs on restart
+        self._cache.xgroup_create(_STREAM, _GROUP, id='0', mkstream=True)
+        logger.info(
+            f'AsyncAgenticExecutionResultConsumer started — stream={_STREAM}, '
+            f'group={_GROUP}, consumer={_CONSUMER}'
+        )
+
+        while self._running:
+            try:
+                messages = await asyncio.to_thread(
+                    self._cache.xread_group,
+                    _GROUP,
+                    _CONSUMER,
+                    {_STREAM: '>'},
+                    _POLL_COUNT,
+                    _BLOCK_MS,
+                )
+
+                for _stream_name, entries in messages:
+                    for msg_id, fields in entries:
+                        try:
+                            await self._process(fields)
+                            await asyncio.to_thread(
+                                self._cache.xack, _STREAM, _GROUP, msg_id
+                            )
+                        except Exception as e:
+                            logger.error(
+                                f'Failed to process stream message {msg_id}: {e}. '
+                                'Message will be redelivered on next consumer restart.'
+                            )
+
+            except Exception as e:
+                logger.error(f'AsyncAgenticExecutionResultConsumer poll error: {e}')
+                await asyncio.sleep(2)  # brief back-off before retrying
+
+    def stop(self) -> None:
+        self._running = False
+        logger.info('AsyncAgenticExecutionResultConsumer stopping')
+
+    async def _process(self, fields: dict) -> None:
+        execution_id_str = fields.get('execution_id')
+        status = fields.get('status')
+
+        if not execution_id_str or not status:
+            logger.warning(f'Stream message missing execution_id or status: {fields}')
+            return
+
+        execution_id = UUID(execution_id_str)
+
+        # Build update kwargs — only include non-empty fields
+        update_kwargs = {'status': status}
+
+        if fields.get('started_at'):
+            update_kwargs['started_at'] = _parse_dt(fields['started_at'])
+
+        if fields.get('completed_at'):
+            update_kwargs['completed_at'] = _parse_dt(fields['completed_at'])
+
+        error = fields.get('error', '')
+        if error:
+            update_kwargs['error'] = error
+        elif status in ('in_progress',):
+            # Clear any previous error on retry
+            update_kwargs['error'] = None
+
+        if fields.get('output_file'):
+            update_kwargs['output_file'] = fields['output_file']
+
+        if fields.get('history_file'):
+            update_kwargs['history_file'] = fields['history_file']
+
+        if fields.get('input_bucket'):
+            update_kwargs['input_bucket'] = fields['input_bucket']
+
+        await self._repo.find_one_and_update({'id': execution_id}, **update_kwargs)
+
+        logger.info(
+            f'Updated async_agentic_executions: execution_id={execution_id}, status={status}'
+        )
+
+        # Update Redis status cache so the next poll is served from cache
+        cache_key = f'{_STATUS_CACHE_KEY_PREFIX}:{execution_id}'
+        if status in ('completed', 'failed'):
+            # Fetch the full record and cache it for 1 hour
+            record = await self._repo.find_one(id=execution_id)
+            if record:
+                await asyncio.to_thread(
+                    self._cache.add,
+                    cache_key,
+                    json.dumps(record.to_dict()),
+                    _STATUS_CACHE_TTL_TERMINAL,
+                )
+        else:
+            # Invalidate stale cache so next GET hits DB
+            await asyncio.to_thread(self._cache.remove, cache_key)
+
+
+def _parse_dt(value: str) -> Optional[datetime]:
+    try:
+        return datetime.fromisoformat(value)
+    except (ValueError, TypeError):
+        return None

--- a/wavefront/server/modules/agents_module/agents_module/services/async_agentic_execution_service.py
+++ b/wavefront/server/modules/agents_module/agents_module/services/async_agentic_execution_service.py
@@ -1,0 +1,383 @@
+import asyncio
+import base64
+import json
+import uuid
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple
+from uuid import UUID
+
+from common_module.log.logger import logger
+from db_repo_module.cache.cache_manager import CacheManager
+from db_repo_module.models.async_agentic_execution import AsyncAgenticExecution
+from db_repo_module.repositories.sql_alchemy_repository import SQLAlchemyRepository
+from flo_cloud.cloud_storage import CloudStorageManager
+
+from agents_module.models.async_agentic_execution_schemas import (
+    AsyncInferenceResponse,
+    AgenticExecutionStatusResponse,
+)
+from agents_module.utils.celery_client import get_celery_client
+
+_MIME_TO_EXT = {
+    'application/pdf': '.pdf',
+    'image/png': '.png',
+    'image/jpeg': '.jpg',
+    'image/jpg': '.jpg',
+    'image/gif': '.gif',
+    'image/webp': '.webp',
+    'image/svg+xml': '.svg',
+    'text/plain': '.txt',
+    'text/csv': '.csv',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document': '.docx',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': '.xlsx',
+}
+
+_AGENT_TASK_NAME = 'celery_worker.tasks.agent_task.execute_agent_task'
+_WORKFLOW_TASK_NAME = 'celery_worker.tasks.workflow_task.execute_workflow_task'
+
+_STATUS_CACHE_TTL_TERMINAL = 3600  # 1 hour for completed/failed
+_STATUS_CACHE_TTL_ACTIVE = 10  # 10 seconds for pending/in_progress
+
+
+def _cache_key(execution_id: UUID) -> str:
+    return f'async_agentic_exec:status:{execution_id}'
+
+
+def _safe_filename(idx: int, file_name: Optional[str], mime_type: Optional[str]) -> str:
+    if file_name:
+        return f'{idx}_{file_name}'
+    ext = _MIME_TO_EXT.get(mime_type or '', '.bin')
+    return f'{idx}_file{ext}'
+
+
+class AsyncAgenticExecutionService:
+    def __init__(
+        self,
+        async_agentic_execution_repository: SQLAlchemyRepository[AsyncAgenticExecution],
+        cloud_storage_manager: CloudStorageManager,
+        cache_manager: CacheManager,
+        executions_bucket: str,
+    ):
+        self.repo = async_agentic_execution_repository
+        self.cloud_storage = cloud_storage_manager
+        self.cache = cache_manager
+        self.bucket = executions_bucket
+
+    def pre_save_binary_inputs(
+        self,
+        inputs: Any,
+        prefix: str,
+    ) -> Tuple[List[Dict], List[Dict]]:
+        """
+        Saves document/image base64 payloads to cloud storage.
+        Returns (clean_inputs, stored_files) where:
+          - clean_inputs: JSON-serializable list — text messages unchanged,
+            binary entries replaced with {stored:true, bucket, key, ...}
+          - stored_files: file-only subset for the input_files DB column
+        """
+        if isinstance(inputs, str):
+            return [{'role': 'user', 'content': inputs}], []
+
+        clean_inputs: List[Dict] = []
+        stored_files: List[Dict] = []
+
+        for idx, item in enumerate(inputs):
+            if not isinstance(item, dict):
+                clean_inputs.append({'role': 'user', 'content': str(item)})
+                continue
+
+            role = item.get('role', 'user')
+            content = item.get('content', '')
+
+            if role == 'assistant':
+                clean_inputs.append({'role': 'assistant', 'content': content})
+                continue
+
+            if isinstance(content, str):
+                clean_inputs.append({'role': 'user', 'content': content})
+                continue
+
+            # Determine if binary input
+            if isinstance(content, dict):
+                doc_b64 = content.get('document_base64')
+                img_b64 = content.get('image_base64')
+                mime_type = content.get('mime_type')
+                file_name = content.get('file_name')
+
+                if doc_b64 is not None:
+                    input_type = 'document'
+                    raw_b64 = doc_b64
+                elif img_b64 is not None:
+                    input_type = 'image'
+                    raw_b64 = img_b64
+                    # Strip data URL prefix if present
+                    if isinstance(raw_b64, str) and raw_b64.startswith('data:'):
+                        parts = raw_b64.split(',', 1)
+                        if len(parts) == 2:
+                            header = parts[0]  # e.g. "data:image/png;base64"
+                            raw_b64 = parts[1]
+                            if not mime_type and ';' in header:
+                                mime_type = header.split(':')[1].split(';')[0]
+                else:
+                    # Unknown content structure — pass through as-is
+                    clean_inputs.append(item)
+                    continue
+
+                safe_name = _safe_filename(idx, file_name, mime_type)
+                key = f'{prefix}inputs/{safe_name}'
+
+                file_bytes = base64.b64decode(raw_b64)
+                self.cloud_storage.save_small_file(
+                    file_content=file_bytes,
+                    bucket_name=self.bucket,
+                    key=key,
+                )
+
+                ref = {
+                    'role': 'user',
+                    'stored': True,
+                    'bucket': self.bucket,
+                    'key': key,
+                    'file_name': file_name or safe_name,
+                    'mime_type': mime_type,
+                    'input_type': input_type,
+                }
+                if content.get('file_name'):
+                    ref['original_file_name'] = content['file_name']
+
+                clean_inputs.append(ref)
+                stored_files.append(
+                    {
+                        'key': key,
+                        'file_name': file_name or safe_name,
+                        'mime_type': mime_type,
+                        'input_type': input_type,
+                    }
+                )
+            else:
+                clean_inputs.append(item)
+
+        return clean_inputs, stored_files
+
+    async def create_and_enqueue_agent(
+        self,
+        agent_id: UUID,
+        inputs: Any,
+        variables: Optional[Dict[str, Any]],
+        output_json_enabled: bool,
+        access_token: Optional[str],
+        app_key: Optional[str],
+        llm_config: Optional[Dict] = None,
+    ) -> AsyncInferenceResponse:
+        execution_id = uuid.uuid4()
+        prefix = f'executions/agents/{agent_id}/{execution_id}/'
+
+        clean_inputs, stored_files = await asyncio.to_thread(
+            self.pre_save_binary_inputs, inputs, prefix
+        )
+
+        await self.repo.create(
+            id=execution_id,
+            entity_type='agent',
+            entity_id=agent_id,
+            status='pending',
+            input_bucket=self.bucket,
+            inputs=json.dumps(clean_inputs),
+            input_files=json.dumps(stored_files) if stored_files else None,
+        )
+
+        payload = {
+            'execution_id': str(execution_id),
+            'entity_id': str(agent_id),
+            'entity_type': 'agent',
+            'variables': variables or {},
+            'inputs': clean_inputs,
+            'llm_config': llm_config,
+            'output_json_enabled': output_json_enabled,
+            'access_token': access_token,
+            'app_key': app_key,
+            'execution_bucket': self.bucket,
+            'output_prefix': prefix,
+        }
+
+        result = get_celery_client().send_task(
+            _AGENT_TASK_NAME,
+            kwargs={'payload': payload},
+        )
+
+        await self.repo.find_one_and_update(
+            {'id': execution_id}, celery_task_id=result.id
+        )
+
+        logger.info(f'Enqueued agent execution {execution_id}, celery task {result.id}')
+        return AsyncInferenceResponse(
+            execution_id=execution_id,
+            status='pending',
+            entity_type='agent',
+            entity_id=agent_id,
+            status_url=f'/v1/agentic-executions/{execution_id}',
+        )
+
+    async def create_and_enqueue_workflow(
+        self,
+        workflow_id: UUID,
+        workflow_name: str,
+        namespace: str,
+        inputs: Any,
+        variables: Optional[Dict[str, Any]],
+        output_json_enabled: bool,
+        access_token: Optional[str],
+        app_key: Optional[str],
+    ) -> AsyncInferenceResponse:
+        execution_id = uuid.uuid4()
+        prefix = f'executions/workflows/{workflow_id}/{execution_id}/'
+
+        clean_inputs, stored_files = await asyncio.to_thread(
+            self.pre_save_binary_inputs, inputs, prefix
+        )
+
+        await self.repo.create(
+            id=execution_id,
+            entity_type='workflow',
+            entity_id=workflow_id,
+            status='pending',
+            input_bucket=self.bucket,
+            inputs=json.dumps(clean_inputs),
+            input_files=json.dumps(stored_files) if stored_files else None,
+        )
+
+        payload = {
+            'execution_id': str(execution_id),
+            'entity_id': str(workflow_id),
+            'entity_type': 'workflow',
+            'workflow_name': workflow_name,
+            'namespace': namespace,
+            'variables': variables or {},
+            'inputs': clean_inputs,
+            'llm_config': None,
+            'output_json_enabled': output_json_enabled,
+            'access_token': access_token,
+            'app_key': app_key,
+            'execution_bucket': self.bucket,
+            'output_prefix': prefix,
+        }
+
+        result = get_celery_client().send_task(
+            _WORKFLOW_TASK_NAME,
+            kwargs={'payload': payload},
+        )
+
+        await self.repo.find_one_and_update(
+            {'id': execution_id}, celery_task_id=result.id
+        )
+
+        logger.info(
+            f'Enqueued workflow execution {execution_id}, celery task {result.id}'
+        )
+        return AsyncInferenceResponse(
+            execution_id=execution_id,
+            status='pending',
+            entity_type='workflow',
+            entity_id=workflow_id,
+            status_url=f'/v1/agentic-executions/{execution_id}',
+        )
+
+    def _build_status_response(
+        self, record_dict: Dict
+    ) -> AgenticExecutionStatusResponse:
+        output_url = None
+        history_url = None
+
+        if record_dict.get('output_file') and record_dict.get('input_bucket'):
+            try:
+                output_url = self.cloud_storage.generate_presigned_url(
+                    bucket_name=record_dict['input_bucket'],
+                    key=record_dict['output_file'],
+                    type='get',
+                    expiresIn=900,
+                )
+            except Exception as e:
+                logger.warning(f'Failed to generate output presigned URL: {e}')
+
+        if record_dict.get('history_file') and record_dict.get('input_bucket'):
+            try:
+                history_url = self.cloud_storage.generate_presigned_url(
+                    bucket_name=record_dict['input_bucket'],
+                    key=record_dict['history_file'],
+                    type='get',
+                    expiresIn=900,
+                )
+            except Exception as e:
+                logger.warning(f'Failed to generate history presigned URL: {e}')
+
+        input_files = None
+        if record_dict.get('input_files'):
+            try:
+                input_files = json.loads(record_dict['input_files'])
+            except Exception:
+                pass
+
+        return AgenticExecutionStatusResponse(
+            id=uuid.UUID(record_dict['id']),
+            entity_type=record_dict['entity_type'],
+            entity_id=uuid.UUID(record_dict['entity_id']),
+            celery_task_id=record_dict.get('celery_task_id'),
+            status=record_dict['status'],
+            error=record_dict.get('error'),
+            input_files=input_files,
+            output_url=output_url,
+            history_url=history_url,
+            started_at=datetime.fromisoformat(record_dict['started_at'])
+            if record_dict.get('started_at')
+            else None,
+            completed_at=datetime.fromisoformat(record_dict['completed_at'])
+            if record_dict.get('completed_at')
+            else None,
+            created_at=datetime.fromisoformat(record_dict['created_at']),
+        )
+
+    async def get_execution_status(
+        self, execution_id: UUID
+    ) -> AgenticExecutionStatusResponse:
+        cache_key = _cache_key(execution_id)
+        cached = await asyncio.to_thread(self.cache.get_str, cache_key)
+
+        if cached:
+            logger.debug(f'Cache hit for execution status {execution_id}')
+            return self._build_status_response(json.loads(cached))
+
+        record = await self.repo.find_one(id=execution_id)
+        if not record:
+            raise ValueError(f'Execution not found: {execution_id}')
+
+        record_dict = record.to_dict()
+        status = record_dict['status']
+        ttl = (
+            _STATUS_CACHE_TTL_TERMINAL
+            if status in ('completed', 'failed')
+            else _STATUS_CACHE_TTL_ACTIVE
+        )
+        await asyncio.to_thread(self.cache.add, cache_key, json.dumps(record_dict), ttl)
+
+        return self._build_status_response(record_dict)
+
+    async def list_executions(
+        self,
+        entity_id: Optional[UUID] = None,
+        entity_type: Optional[str] = None,
+        status: Optional[str] = None,
+        offset: int = 0,
+        limit: int = 50,
+    ) -> List[AgenticExecutionStatusResponse]:
+        filters: Dict[str, Any] = {}
+        if entity_id:
+            filters['entity_id'] = entity_id
+        if entity_type:
+            filters['entity_type'] = entity_type
+        if status:
+            filters['status'] = status
+
+        records = await self.repo.find(**filters, limit=limit)
+        records = records[offset:]
+
+        return [self._build_status_response(r.to_dict()) for r in records]

--- a/wavefront/server/modules/agents_module/agents_module/services/async_agentic_execution_service.py
+++ b/wavefront/server/modules/agents_module/agents_module/services/async_agentic_execution_service.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+import binascii
 import json
 import uuid
 from datetime import datetime
@@ -126,7 +127,12 @@ class AsyncAgenticExecutionService:
                 safe_name = _safe_filename(idx, file_name, mime_type)
                 key = f'{prefix}inputs/{safe_name}'
 
-                file_bytes = base64.b64decode(raw_b64)
+                try:
+                    file_bytes = base64.b64decode(raw_b64, validate=True)
+                except (binascii.Error, ValueError) as exc:
+                    raise ValueError(
+                        f'Invalid base64 data for input at index {idx}: {exc}'
+                    ) from exc
                 self.cloud_storage.save_small_file(
                     file_content=file_bytes,
                     bucket_name=self.bucket,
@@ -200,10 +206,17 @@ class AsyncAgenticExecutionService:
             'output_prefix': prefix,
         }
 
-        result = get_celery_client().send_task(
-            _AGENT_TASK_NAME,
-            kwargs={'payload': payload},
-        )
+        try:
+            result = get_celery_client().send_task(
+                _AGENT_TASK_NAME,
+                kwargs={'payload': payload},
+            )
+        except Exception as exc:
+            await self.repo.find_one_and_update(
+                {'id': execution_id}, status='failed', error=str(exc)
+            )
+            logger.error(f'Failed to enqueue agent execution {execution_id}: {exc}')
+            raise
 
         await self.repo.find_one_and_update(
             {'id': execution_id}, celery_task_id=result.id
@@ -262,10 +275,17 @@ class AsyncAgenticExecutionService:
             'output_prefix': prefix,
         }
 
-        result = get_celery_client().send_task(
-            _WORKFLOW_TASK_NAME,
-            kwargs={'payload': payload},
-        )
+        try:
+            result = get_celery_client().send_task(
+                _WORKFLOW_TASK_NAME,
+                kwargs={'payload': payload},
+            )
+        except Exception as exc:
+            await self.repo.find_one_and_update(
+                {'id': execution_id}, status='failed', error=str(exc)
+            )
+            logger.error(f'Failed to enqueue workflow execution {execution_id}: {exc}')
+            raise
 
         await self.repo.find_one_and_update(
             {'id': execution_id}, celery_task_id=result.id
@@ -377,7 +397,7 @@ class AsyncAgenticExecutionService:
         if status:
             filters['status'] = status
 
-        records = await self.repo.find(**filters, limit=limit)
+        records = await self.repo.find(**filters, limit=offset + limit)
         records = records[offset:]
 
         return [self._build_status_response(r.to_dict()) for r in records]

--- a/wavefront/server/modules/agents_module/agents_module/utils/celery_client.py
+++ b/wavefront/server/modules/agents_module/agents_module/utils/celery_client.py
@@ -4,4 +4,7 @@ from celery import Celery
 
 
 def get_celery_client() -> Celery:
-    return Celery('async_executor', broker=os.environ['CELERY_BROKER_URL'])
+    broker_url = os.getenv('CELERY_BROKER_URL')
+    if not broker_url:
+        raise RuntimeError('Missing required env var: CELERY_BROKER_URL')
+    return Celery('async_executor', broker=broker_url)

--- a/wavefront/server/modules/agents_module/agents_module/utils/celery_client.py
+++ b/wavefront/server/modules/agents_module/agents_module/utils/celery_client.py
@@ -1,0 +1,7 @@
+import os
+
+from celery import Celery
+
+
+def get_celery_client() -> Celery:
+    return Celery('async_executor', broker=os.environ['CELERY_BROKER_URL'])

--- a/wavefront/server/modules/agents_module/pyproject.toml
+++ b/wavefront/server/modules/agents_module/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "tools-module",
     "api-services-module",
     "flo-ai==1.1.6",
+    "celery[redis]>=5.4.0,<6.0.0",
 ]
 
 [tool.uv.sources]

--- a/wavefront/server/modules/db_repo_module/db_repo_module/alembic/versions/2026_05_12_1549-3b5b1bf90e6c_add_async_agentic_executions.py
+++ b/wavefront/server/modules/db_repo_module/db_repo_module/alembic/versions/2026_05_12_1549-3b5b1bf90e6c_add_async_agentic_executions.py
@@ -1,0 +1,107 @@
+"""add_async_agentic_executions
+
+Revision ID: 3b5b1bf90e6c
+Revises: e8f2a1c3b5d9
+Create Date: 2026-05-12 15:49:11.063050
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = '3b5b1bf90e6c'
+down_revision: Union[str, None] = 'e8f2a1c3b5d9'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'async_agentic_executions',
+        sa.Column('id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('entity_type', sa.String(length=32), nullable=False),
+        sa.Column('entity_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('celery_task_id', sa.String(length=255), nullable=True),
+        sa.Column(
+            'status',
+            sa.String(length=32),
+            nullable=False,
+            server_default=sa.text("'pending'"),
+        ),
+        sa.Column('input_bucket', sa.String(length=255), nullable=True),
+        sa.Column('inputs', sa.Text(), nullable=True),
+        sa.Column('input_files', sa.Text(), nullable=True),
+        sa.Column('output_file', sa.String(length=1024), nullable=True),
+        sa.Column('history_file', sa.String(length=1024), nullable=True),
+        sa.Column('error', sa.Text(), nullable=True),
+        sa.Column('started_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('completed_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            'created_at',
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text('now()'),
+        ),
+        sa.Column(
+            'updated_at',
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text('now()'),
+        ),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(
+        op.f('ix_async_agentic_executions_id'),
+        'async_agentic_executions',
+        ['id'],
+        unique=False,
+    )
+    op.create_index(
+        'ix_async_agentic_executions_entity_id',
+        'async_agentic_executions',
+        ['entity_id'],
+        unique=False,
+    )
+    op.create_index(
+        'ix_async_agentic_executions_entity_type',
+        'async_agentic_executions',
+        ['entity_type'],
+        unique=False,
+    )
+    op.create_index(
+        'ix_async_agentic_executions_status',
+        'async_agentic_executions',
+        ['status'],
+        unique=False,
+    )
+    op.create_index(
+        'ix_async_agentic_executions_entity_status',
+        'async_agentic_executions',
+        ['entity_id', 'entity_type', 'status'],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        'ix_async_agentic_executions_entity_status',
+        table_name='async_agentic_executions',
+    )
+    op.drop_index(
+        'ix_async_agentic_executions_status', table_name='async_agentic_executions'
+    )
+    op.drop_index(
+        'ix_async_agentic_executions_entity_type', table_name='async_agentic_executions'
+    )
+    op.drop_index(
+        'ix_async_agentic_executions_entity_id', table_name='async_agentic_executions'
+    )
+    op.drop_index(
+        op.f('ix_async_agentic_executions_id'), table_name='async_agentic_executions'
+    )
+    op.drop_table('async_agentic_executions')

--- a/wavefront/server/modules/db_repo_module/db_repo_module/cache/cache_manager.py
+++ b/wavefront/server/modules/db_repo_module/db_repo_module/cache/cache_manager.py
@@ -307,6 +307,11 @@ class CacheManager(CommonCache):
                 logger.error(f'Error creating consumer group {group}: {e}')
                 raise
 
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=1, max=10),
+        retry=retry_if_exception_type((RedisError, ConnectionError, TimeoutError)),
+    )
     def xread_group(
         self,
         group: str,

--- a/wavefront/server/modules/db_repo_module/db_repo_module/cache/cache_manager.py
+++ b/wavefront/server/modules/db_repo_module/db_repo_module/cache/cache_manager.py
@@ -272,6 +272,79 @@ class CacheManager(CommonCache):
             logger.error(f'Error subscribing to channels/patterns: {e}')
             raise
 
+    # ------------------------------------------------------------------
+    # Redis Streams
+    # ------------------------------------------------------------------
+
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=1, max=10),
+        retry=retry_if_exception_type((RedisError, ConnectionError, TimeoutError)),
+    )
+    def xadd(self, stream: str, fields: dict, maxlen: int = 10000) -> str:
+        """Append an entry to a Redis Stream. Returns the message ID."""
+        try:
+            return self.redis.xadd(f'{self.namespace}/{stream}', fields, maxlen=maxlen)
+        except (RedisError, ConnectionError, TimeoutError) as e:
+            logger.error(f'Error appending to stream {stream}: {e}')
+            raise
+
+    def xgroup_create(
+        self, stream: str, group: str, id: str = '$', mkstream: bool = True
+    ) -> None:
+        """Create a consumer group. Silently ignores BUSYGROUP if already exists."""
+        try:
+            self.redis.xgroup_create(
+                f'{self.namespace}/{stream}', group, id=id, mkstream=mkstream
+            )
+            logger.info(f'Created consumer group {group} on stream {stream}')
+        except Exception as e:
+            if 'BUSYGROUP' in str(e):
+                logger.debug(
+                    f'Consumer group {group} already exists on stream {stream}'
+                )
+            else:
+                logger.error(f'Error creating consumer group {group}: {e}')
+                raise
+
+    def xread_group(
+        self,
+        group: str,
+        consumer: str,
+        streams: dict,
+        count: int = 10,
+        block_ms: int = 1000,
+    ) -> list:
+        """Read messages from stream(s) via consumer group.
+
+        Args:
+            streams: mapping of stream_name → '>' (undelivered) or message ID (pending)
+        """
+        try:
+            namespaced = {f'{self.namespace}/{k}': v for k, v in streams.items()}
+            return (
+                self.redis.xreadgroup(
+                    group, consumer, namespaced, count=count, block=block_ms
+                )
+                or []
+            )
+        except (RedisError, ConnectionError, TimeoutError) as e:
+            logger.error(f'Error reading from stream group {group}: {e}')
+            raise
+
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=1, max=10),
+        retry=retry_if_exception_type((RedisError, ConnectionError, TimeoutError)),
+    )
+    def xack(self, stream: str, group: str, *message_ids: str) -> int:
+        """Acknowledge one or more messages in a consumer group."""
+        try:
+            return self.redis.xack(f'{self.namespace}/{stream}', group, *message_ids)
+        except (RedisError, ConnectionError, TimeoutError) as e:
+            logger.error(f'Error acknowledging messages on stream {stream}: {e}')
+            raise
+
     def close(self):
         try:
             self.pool.disconnect()

--- a/wavefront/server/modules/db_repo_module/db_repo_module/db_repo_container.py
+++ b/wavefront/server/modules/db_repo_module/db_repo_module/db_repo_container.py
@@ -35,6 +35,7 @@ from db_repo_module.models.namespace import Namespace
 from db_repo_module.models.agent import Agent
 from db_repo_module.models.workflow import Workflow
 from db_repo_module.models.api_services import ApiServices
+from db_repo_module.models.async_agentic_execution import AsyncAgenticExecution
 from dependency_injector import containers
 from dependency_injector import providers
 
@@ -231,5 +232,11 @@ class DatabaseModuleContainer(containers.DeclarativeContainer):
     knowledge_base_inference_repository = providers.Singleton(
         SQLAlchemyRepository[KnowledgeBaseInferences],
         model=KnowledgeBaseInferences,
+        db_client=db_client,
+    )
+
+    async_agentic_execution_repository = providers.Singleton(
+        SQLAlchemyRepository[AsyncAgenticExecution],
+        model=AsyncAgenticExecution,
         db_client=db_client,
     )

--- a/wavefront/server/modules/db_repo_module/db_repo_module/models/async_agentic_execution.py
+++ b/wavefront/server/modules/db_repo_module/db_repo_module/models/async_agentic_execution.py
@@ -1,0 +1,55 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Text
+from sqlalchemy.orm import Mapped
+from sqlalchemy.orm import mapped_column
+
+from ..database.base import Base
+
+
+class AsyncAgenticExecution(Base):
+    __tablename__ = 'async_agentic_executions'
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        primary_key=True, default=uuid.uuid4, index=True
+    )
+    entity_type: Mapped[str] = mapped_column(nullable=False)  # 'agent' or 'workflow'
+    entity_id: Mapped[uuid.UUID] = mapped_column(nullable=False, index=True)
+    celery_task_id: Mapped[str] = mapped_column(nullable=True)
+    status: Mapped[str] = mapped_column(
+        nullable=False, index=True
+    )  # 'pending' | 'in_progress' | 'completed' | 'failed'
+    input_bucket: Mapped[str] = mapped_column(nullable=True)
+    inputs: Mapped[str] = mapped_column(Text, nullable=True)
+    input_files: Mapped[str] = mapped_column(nullable=True)
+    output_file: Mapped[str] = mapped_column(nullable=True)
+    history_file: Mapped[str] = mapped_column(nullable=True)
+    error: Mapped[str] = mapped_column(Text, nullable=True)
+    started_at: Mapped[datetime] = mapped_column(nullable=True)
+    completed_at: Mapped[datetime] = mapped_column(nullable=True)
+    created_at: Mapped[datetime] = mapped_column(default=datetime.now)
+    updated_at: Mapped[datetime] = mapped_column(
+        default=datetime.now, onupdate=datetime.now
+    )
+
+    def to_dict(self):
+        return {
+            'id': str(self.id),
+            'entity_type': self.entity_type,
+            'entity_id': str(self.entity_id),
+            'celery_task_id': self.celery_task_id,
+            'status': self.status,
+            'input_bucket': self.input_bucket,
+            'inputs': self.inputs,
+            'input_files': self.input_files,
+            'output_file': self.output_file,
+            'history_file': self.history_file,
+            'error': self.error,
+            'started_at': self.started_at.isoformat() if self.started_at else None,
+            'completed_at': self.completed_at.isoformat()
+            if self.completed_at
+            else None,
+            'created_at': self.created_at.isoformat(),
+            'updated_at': self.updated_at.isoformat(),
+        }

--- a/wavefront/server/uv.lock
+++ b/wavefront/server/uv.lock
@@ -23,6 +23,7 @@ members = [
     "auth-module",
     "authenticator",
     "call-processing",
+    "celery-worker",
     "common-module",
     "datasource",
     "db-repo-module",
@@ -79,6 +80,7 @@ version = "0.1.0"
 source = { editable = "modules/agents_module" }
 dependencies = [
     { name = "api-services-module" },
+    { name = "celery", extra = ["redis"] },
     { name = "common-module" },
     { name = "flo-ai" },
     { name = "flo-cloud" },
@@ -89,6 +91,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "api-services-module", editable = "modules/api_services_module" },
+    { name = "celery", extras = ["redis"], specifier = ">=5.4.0,<6.0.0" },
     { name = "common-module", editable = "modules/common_module" },
     { name = "flo-ai", specifier = "==1.1.6" },
     { name = "flo-cloud", editable = "packages/flo_cloud" },
@@ -219,6 +222,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9a/ca/4dc52902cf3491892d464f5265a81e9dff094692c8a049a3ed6a05fe7ee8/alembic-1.16.5.tar.gz", hash = "sha256:a88bb7f6e513bd4301ecf4c7f2206fe93f9913f9b48dac3b78babde2d6fe765e", size = 1969868, upload-time = "2025-08-27T18:02:05.668Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/4a/4c61d4c84cfd9befb6fa08a702535b27b21fff08c946bc2f6139decbf7f7/alembic-1.16.5-py3-none-any.whl", hash = "sha256:e845dfe090c5ffa7b92593ae6687c5cb1a101e91fa53868497dbd79847f9dbe3", size = 247355, upload-time = "2025-08-27T18:02:07.37Z" },
+]
+
+[[package]]
+name = "amqp"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "vine" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/fc/ec94a357dfc6683d8c86f8b4cfa5416a4c36b28052ec8260c77aca96a443/amqp-5.3.1.tar.gz", hash = "sha256:cddc00c725449522023bad949f70fff7b48f0b1ade74d170a6f10ab044739432", size = 129013, upload-time = "2024-11-12T19:55:44.051Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/99/fc813cd978842c26c82534010ea849eee9ab3a13ea2b74e95cb9c99e747b/amqp-5.3.1-py3-none-any.whl", hash = "sha256:43b3319e1b4e7d1251833a93d672b4af1e40f3d632d479b98661a95f117880a2", size = 50944, upload-time = "2024-11-12T19:55:41.782Z" },
 ]
 
 [[package]]
@@ -634,6 +649,15 @@ wheels = [
 ]
 
 [[package]]
+name = "billiard"
+version = "4.2.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/23/b12ac0bcdfb7360d664f40a00b1bda139cbbbced012c34e375506dbd0143/billiard-4.2.4.tar.gz", hash = "sha256:55f542c371209e03cd5862299b74e52e4fbcba8250ba611ad94276b369b6a85f", size = 156537, upload-time = "2025-11-30T13:28:48.52Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/87/8bab77b323f16d67be364031220069f79159117dd5e43eeb4be2fef1ac9b/billiard-4.2.4-py3-none-any.whl", hash = "sha256:525b42bdec68d2b983347ac312f892db930858495db601b5836ac24e6477cde5", size = 87070, upload-time = "2025-11-30T13:28:47.016Z" },
+]
+
+[[package]]
 name = "boto3"
 version = "1.38.27"
 source = { registry = "https://pypi.org/simple" }
@@ -719,6 +743,60 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fa/ff/bfd3191a7fdbbb5c4dfe4d34461c6aa0d158a6eea599cb9a5df2c91109fa/cartesia-2.0.17.tar.gz", hash = "sha256:fd7fcdcbb5aac47ff6b35cd48420b4993ef1742aaa71bb7d52b335314045d584", size = 79227, upload-time = "2025-11-13T21:06:45.332Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/9c/f7b83329e0567d0ab165abd81405108d146abc9728732c1af3858ee38bfd/cartesia-2.0.17-py3-none-any.whl", hash = "sha256:de8975ced1c5c09f1b51bb87ceea6c1641ba817901cfc73c47fc4e37c6ca351a", size = 153376, upload-time = "2025-11-13T21:06:42.872Z" },
+]
+
+[[package]]
+name = "celery"
+version = "5.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "billiard" },
+    { name = "click" },
+    { name = "click-didyoumean" },
+    { name = "click-plugins" },
+    { name = "click-repl" },
+    { name = "kombu" },
+    { name = "python-dateutil" },
+    { name = "tzlocal" },
+    { name = "vine" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e8/b4/a1233943ab5c8ea05fb877a88a0a0622bf47444b99e4991a8045ac37ea1d/celery-5.6.3.tar.gz", hash = "sha256:177006bd2054b882e9f01be59abd8529e88879ef50d7918a7050c5a9f4e12912", size = 1742243, upload-time = "2026-03-26T12:14:51.76Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/c9/6eccdda96e098f7ae843162db2d3c149c6931a24fda69fe4ab84d0027eb5/celery-5.6.3-py3-none-any.whl", hash = "sha256:0808f42f80909c4d5833202360ffafb2a4f83f4d8e23e1285d926610e9a7afa6", size = 451235, upload-time = "2026-03-26T12:14:49.491Z" },
+]
+
+[package.optional-dependencies]
+redis = [
+    { name = "kombu", extra = ["redis"] },
+]
+
+[[package]]
+name = "celery-worker"
+version = "0.1.0"
+source = { editable = "background_jobs/celery_worker" }
+dependencies = [
+    { name = "agents-module" },
+    { name = "api-services-module" },
+    { name = "celery", extra = ["redis"] },
+    { name = "common-module" },
+    { name = "db-repo-module" },
+    { name = "flo-cloud" },
+    { name = "flo-utils" },
+    { name = "python-dotenv" },
+    { name = "tools-module" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "agents-module", editable = "modules/agents_module" },
+    { name = "api-services-module", editable = "modules/api_services_module" },
+    { name = "celery", extras = ["redis"], specifier = ">=5.4.0,<6.0.0" },
+    { name = "common-module", editable = "modules/common_module" },
+    { name = "db-repo-module", editable = "modules/db_repo_module" },
+    { name = "flo-cloud", editable = "packages/flo_cloud" },
+    { name = "flo-utils", editable = "packages/flo_utils" },
+    { name = "python-dotenv", specifier = ">=1.1.0,<2.0.0" },
+    { name = "tools-module", editable = "modules/tools_module" },
 ]
 
 [[package]]
@@ -881,6 +959,43 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342, upload-time = "2025-05-20T23:19:49.832Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b", size = 102215, upload-time = "2025-05-20T23:19:47.796Z" },
+]
+
+[[package]]
+name = "click-didyoumean"
+version = "0.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/30/ce/217289b77c590ea1e7c24242d9ddd6e249e52c795ff10fac2c50062c48cb/click_didyoumean-0.3.1.tar.gz", hash = "sha256:4f82fdff0dbe64ef8ab2279bd6aa3f6a99c3b28c05aa09cbfc07c9d7fbb5a463", size = 3089, upload-time = "2024-03-24T08:22:07.499Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/5b/974430b5ffdb7a4f1941d13d83c64a0395114503cc357c6b9ae4ce5047ed/click_didyoumean-0.3.1-py3-none-any.whl", hash = "sha256:5c4bb6007cfea5f2fd6583a2fb6701a22a41eb98957e63d0fac41c10e7c3117c", size = 3631, upload-time = "2024-03-24T08:22:06.356Z" },
+]
+
+[[package]]
+name = "click-plugins"
+version = "1.1.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/a4/34847b59150da33690a36da3681d6bbc2ec14ee9a846bc30a6746e5984e4/click_plugins-1.1.1.2.tar.gz", hash = "sha256:d7af3984a99d243c131aa1a828331e7630f4a88a9741fd05c927b204bcf92261", size = 8343, upload-time = "2025-06-25T00:47:37.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/9a/2abecb28ae875e39c8cad711eb1186d8d14eab564705325e77e4e6ab9ae5/click_plugins-1.1.1.2-py2.py3-none-any.whl", hash = "sha256:008d65743833ffc1f5417bf0e78e8d2c23aab04d9745ba817bd3e71b0feb6aa6", size = 11051, upload-time = "2025-06-25T00:47:36.731Z" },
+]
+
+[[package]]
+name = "click-repl"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "prompt-toolkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cb/a2/57f4ac79838cfae6912f997b4d1a64a858fb0c86d7fcaae6f7b58d267fca/click-repl-0.3.0.tar.gz", hash = "sha256:17849c23dba3d667247dc4defe1757fff98694e90fe37474f3feebb69ced26a9", size = 10449, upload-time = "2023-06-15T12:43:51.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/40/9d857001228658f0d59e97ebd4c346fe73e138c6de1bce61dc568a57c7f8/click_repl-0.3.0-py3-none-any.whl", hash = "sha256:fb7e06deb8da8de86180a33a9da97ac316751c094c6899382da7feeeeb51b812", size = 10289, upload-time = "2023-06-15T12:43:48.626Z" },
 ]
 
 [[package]]
@@ -2003,6 +2118,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/de/f28ced0a67749cac23fecb02b694f6473f47686dff6afaa211d186e2ef9c/greenlet-3.2.4-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:96378df1de302bc38e99c3a9aa311967b7dc80ced1dcc6f171e99842987882a2", size = 272305, upload-time = "2025-08-07T13:15:41.288Z" },
     { url = "https://files.pythonhosted.org/packages/09/16/2c3792cba130000bf2a31c5272999113f4764fd9d874fb257ff588ac779a/greenlet-3.2.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1ee8fae0519a337f2329cb78bd7a8e128ec0f881073d43f023c7b8d4831d5246", size = 632472, upload-time = "2025-08-07T13:42:55.044Z" },
     { url = "https://files.pythonhosted.org/packages/ae/8f/95d48d7e3d433e6dae5b1682e4292242a53f22df82e6d3dda81b1701a960/greenlet-3.2.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94abf90142c2a18151632371140b3dba4dee031633fe614cb592dbb6c9e17bc3", size = 644646, upload-time = "2025-08-07T13:45:26.523Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/5e/405965351aef8c76b8ef7ad370e5da58d57ef6068df197548b015464001a/greenlet-3.2.4-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:4d1378601b85e2e5171b99be8d2dc85f594c79967599328f95c1dc1a40f1c633", size = 640519, upload-time = "2025-08-07T13:53:13.928Z" },
     { url = "https://files.pythonhosted.org/packages/25/5d/382753b52006ce0218297ec1b628e048c4e64b155379331f25a7316eb749/greenlet-3.2.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0db5594dce18db94f7d1650d7489909b57afde4c580806b8d9203b6e79cdc079", size = 639707, upload-time = "2025-08-07T13:18:27.146Z" },
     { url = "https://files.pythonhosted.org/packages/1f/8e/abdd3f14d735b2929290a018ecf133c901be4874b858dd1c604b9319f064/greenlet-3.2.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2523e5246274f54fdadbce8494458a2ebdcdbc7b802318466ac5606d3cded1f8", size = 587684, upload-time = "2025-08-07T13:18:25.164Z" },
     { url = "https://files.pythonhosted.org/packages/5d/65/deb2a69c3e5996439b0176f6651e0052542bb6c8f8ec2e3fba97c9768805/greenlet-3.2.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1987de92fec508535687fb807a5cea1560f6196285a4cde35c100b8cd632cc52", size = 1116647, upload-time = "2025-08-07T13:42:38.655Z" },
@@ -2013,6 +2129,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/44/69/9b804adb5fd0671f367781560eb5eb586c4d495277c93bde4307b9e28068/greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd", size = 274079, upload-time = "2025-08-07T13:15:45.033Z" },
     { url = "https://files.pythonhosted.org/packages/46/e9/d2a80c99f19a153eff70bc451ab78615583b8dac0754cfb942223d2c1a0d/greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb", size = 640997, upload-time = "2025-08-07T13:42:56.234Z" },
     { url = "https://files.pythonhosted.org/packages/3b/16/035dcfcc48715ccd345f3a93183267167cdd162ad123cd93067d86f27ce4/greenlet-3.2.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f28588772bb5fb869a8eb331374ec06f24a83a9c25bfa1f38b6993afe9c1e968", size = 655185, upload-time = "2025-08-07T13:45:27.624Z" },
+    { url = "https://files.pythonhosted.org/packages/31/da/0386695eef69ffae1ad726881571dfe28b41970173947e7c558d9998de0f/greenlet-3.2.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5c9320971821a7cb77cfab8d956fa8e39cd07ca44b6070db358ceb7f8797c8c9", size = 649926, upload-time = "2025-08-07T13:53:15.251Z" },
     { url = "https://files.pythonhosted.org/packages/68/88/69bf19fd4dc19981928ceacbc5fd4bb6bc2215d53199e367832e98d1d8fe/greenlet-3.2.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c60a6d84229b271d44b70fb6e5fa23781abb5d742af7b808ae3f6efd7c9c60f6", size = 651839, upload-time = "2025-08-07T13:18:30.281Z" },
     { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },
@@ -2023,6 +2140,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/e8/58c7f85958bda41dafea50497cbd59738c5c43dbbea5ee83d651234398f4/greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31", size = 272814, upload-time = "2025-08-07T13:15:50.011Z" },
     { url = "https://files.pythonhosted.org/packages/62/dd/b9f59862e9e257a16e4e610480cfffd29e3fae018a68c2332090b53aac3d/greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945", size = 641073, upload-time = "2025-08-07T13:42:57.23Z" },
     { url = "https://files.pythonhosted.org/packages/f7/0b/bc13f787394920b23073ca3b6c4a7a21396301ed75a655bcb47196b50e6e/greenlet-3.2.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:710638eb93b1fa52823aa91bf75326f9ecdfd5e0466f00789246a5280f4ba0fc", size = 655191, upload-time = "2025-08-07T13:45:29.752Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/d6/6adde57d1345a8d0f14d31e4ab9c23cfe8e2cd39c3baf7674b4b0338d266/greenlet-3.2.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c5111ccdc9c88f423426df3fd1811bfc40ed66264d35aa373420a34377efc98a", size = 649516, upload-time = "2025-08-07T13:53:16.314Z" },
     { url = "https://files.pythonhosted.org/packages/7f/3b/3a3328a788d4a473889a2d403199932be55b1b0060f4ddd96ee7cdfcad10/greenlet-3.2.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d76383238584e9711e20ebe14db6c88ddcedc1829a9ad31a584389463b5aa504", size = 652169, upload-time = "2025-08-07T13:18:32.861Z" },
     { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
     { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
@@ -2033,6 +2151,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/22/5c/85273fd7cc388285632b0498dbbab97596e04b154933dfe0f3e68156c68c/greenlet-3.2.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:49a30d5fda2507ae77be16479bdb62a660fa51b1eb4928b524975b3bde77b3c0", size = 273586, upload-time = "2025-08-07T13:16:08.004Z" },
     { url = "https://files.pythonhosted.org/packages/d1/75/10aeeaa3da9332c2e761e4c50d4c3556c21113ee3f0afa2cf5769946f7a3/greenlet-3.2.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:299fd615cd8fc86267b47597123e3f43ad79c9d8a22bebdce535e53550763e2f", size = 686346, upload-time = "2025-08-07T13:42:59.944Z" },
     { url = "https://files.pythonhosted.org/packages/c0/aa/687d6b12ffb505a4447567d1f3abea23bd20e73a5bed63871178e0831b7a/greenlet-3.2.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c17b6b34111ea72fc5a4e4beec9711d2226285f0386ea83477cbb97c30a3f3a5", size = 699218, upload-time = "2025-08-07T13:45:30.969Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8b/29aae55436521f1d6f8ff4e12fb676f3400de7fcf27fccd1d4d17fd8fecd/greenlet-3.2.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b4a1870c51720687af7fa3e7cda6d08d801dae660f75a76f3845b642b4da6ee1", size = 694659, upload-time = "2025-08-07T13:53:17.759Z" },
     { url = "https://files.pythonhosted.org/packages/92/2e/ea25914b1ebfde93b6fc4ff46d6864564fba59024e928bdc7de475affc25/greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735", size = 695355, upload-time = "2025-08-07T13:18:34.517Z" },
     { url = "https://files.pythonhosted.org/packages/72/60/fc56c62046ec17f6b0d3060564562c64c862948c9d4bc8aa807cf5bd74f4/greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337", size = 657512, upload-time = "2025-08-07T13:18:33.969Z" },
     { url = "https://files.pythonhosted.org/packages/23/6e/74407aed965a4ab6ddd93a7ded3180b730d281c77b765788419484cdfeef/greenlet-3.2.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2917bdf657f5859fbf3386b12d68ede4cf1f04c90c3a6bc1f013dd68a22e2269", size = 1612508, upload-time = "2025-11-04T12:42:23.427Z" },
@@ -2614,6 +2733,26 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.24.0,<1.0.0" },
     { name = "testing-postgresql", specifier = ">=1.3.0,<2.0.0" },
     { name = "user-management-module", editable = "modules/user_management_module" },
+]
+
+[[package]]
+name = "kombu"
+version = "5.6.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "amqp" },
+    { name = "packaging" },
+    { name = "tzdata" },
+    { name = "vine" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b6/a5/607e533ed6c83ae1a696969b8e1c137dfebd5759a2e9682e26ff1b97740b/kombu-5.6.2.tar.gz", hash = "sha256:8060497058066c6f5aed7c26d7cd0d3b574990b09de842a8c5aaed0b92cc5a55", size = 472594, upload-time = "2025-12-29T20:30:07.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/0f/834427d8c03ff1d7e867d3db3d176470c64871753252b21b4f4897d1fa45/kombu-5.6.2-py3-none-any.whl", hash = "sha256:efcfc559da324d41d61ca311b0c64965ea35b4c55cc04ee36e55386145dace93", size = 214219, upload-time = "2025-12-29T20:30:05.74Z" },
+]
+
+[package.optional-dependencies]
+redis = [
+    { name = "redis" },
 ]
 
 [[package]]
@@ -4091,6 +4230,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/23/53/3edb5d68ecf6b38fcbcc1ad28391117d2a322d9a1a3eff04bfdb184d8c3b/prometheus_client-0.23.1.tar.gz", hash = "sha256:6ae8f9081eaaaf153a2e959d2e6c4f4fb57b12ef76c8c7980202f1e57b48b2ce", size = 80481, upload-time = "2025-09-18T20:47:25.043Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b8/db/14bafcb4af2139e046d03fd00dea7873e48eafe18b7d2797e73d6681f210/prometheus_client-0.23.1-py3-none-any.whl", hash = "sha256:dd1913e6e76b59cfe44e7a4b83e01afc9873c1bdfd2ed8739f1e76aeca115f99", size = 61145, upload-time = "2025-09-18T20:47:23.875Z" },
+]
+
+[[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
 ]
 
 [[package]]
@@ -5980,6 +6131,15 @@ wheels = [
 ]
 
 [[package]]
+name = "vine"
+version = "5.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/e4/d07b5f29d283596b9727dd5275ccbceb63c44a1a82aa9e4bfd20426762ac/vine-5.1.0.tar.gz", hash = "sha256:8b62e981d35c41049211cf62a0a1242d8c1ee9bd15bb196ce38aefd6799e61e0", size = 48980, upload-time = "2023-11-05T08:46:53.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/ff/7c0c86c43b3cbb927e0ccc0255cb4057ceba4799cd44ae95174ce8e8b5b2/vine-5.1.0-py3-none-any.whl", hash = "sha256:40fdf3c48b2cfe1c38a49e9ae2da6fda88e4794c810050a728bd7413811fb1dc", size = 9636, upload-time = "2023-11-05T08:46:51.205Z" },
+]
+
+[[package]]
 name = "virtualenv"
 version = "20.34.0"
 source = { registry = "https://pypi.org/simple" }
@@ -6127,6 +6287,15 @@ dev = [
 dev = [
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "ty", specifier = ">=0.0.1a28" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/ee/afaf0f85a9a18fe47a67f1e4422ed6cf1fe642f0ae0a2f81166231303c52/wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0", size = 182132, upload-time = "2026-05-02T16:04:12.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/52/e465037f5375f43533d1a80b6923955201596a99142ed524d77b571a1418/wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2", size = 110825, upload-time = "2026-05-02T16:04:11.033Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Introduces v3 async inference endpoints for agents and workflows that return immediately with an execution_id, offloading LLM execution to a Celery worker.

Key design decisions:
- Binary inputs (documents/images) are pre-saved to cloud storage before enqueuing so Celery task messages stay small (no base64 in Redis)
- Worker has zero DB access — status updates (in_progress, completed, failed) are published to a Redis Stream (async_agentic_exec:results)
- AsyncAgenticExecutionResultConsumer runs as a background asyncio task inside floware, reads the stream via consumer group, and writes to DB — resilient to floware restarts via consumer group offset tracking
- Presigned URLs for output.json and history.json are generated at response time, never stored

New endpoints:
  POST /floware/v3/agents/{agent_id}/inference     → 202 + execution_id
  POST /floware/v3/workflows/{workflow_id}/inference → 202 + execution_id
  GET  /floware/v1/agentic-executions/{id}          → status + presigned URLs
  GET  /floware/v1/agentic-executions               → list with filters

New table: async_agentic_executions
New package: background_jobs/celery_worker

Retries disabled by default; enable via CELERY_TASK_MAX_RETRIES env var.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-to-end async execution for agents and workflows (enqueue, background processing, status updates).
  * New async REST endpoints to enqueue executions, fetch status, and list executions with filters/pagination.
  * Background worker and task processing with persisted outputs and presigned download links.
  * Real-time status consumption and caching for execution updates.
  * Database migration and schema to store async execution metadata.
* **Chore**
  * Packaging/configuration added for the async worker.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rootflo/wavefront/pull/287)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->