### PR TITLE
Dynamic query to ignore RLS filter when auth is s2s

### DIFF
--- a/wavefront/server/modules/user_management_module/user_management_module/authorization/require_auth.py
+++ b/wavefront/server/modules/user_management_module/user_management_module/authorization/require_auth.py
@@ -359,6 +359,11 @@ class RequireAuthMiddleware(BaseHTTPMiddleware):
                             'Invalid HMAC signature'
                         ),
                     )
+                request.state.session = UserSession(
+                    role_id=SERVICE_AUTH_ROLE_ID,
+                    user_id='hmac-service',
+                    session_id='hmac-token',
+                )
             # Check for service-to-service authentication (Client-Key header + JWT)
             elif request.headers.get(RootfloHeaders.CLIENT_KEY):
                 if not await validate_service_auth(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced session management for HMAC-authenticated requests to ensure downstream handlers have consistent access to session information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->