### PR TITLE
Rag aws fix for creating seperate queue for rags

### DIFF
--- a/wavefront/server/apps/floware/floware/config.ini
+++ b/wavefront/server/apps/floware/floware/config.ini
@@ -83,6 +83,7 @@ aws_asset_storage_bucket=${AWS_GOLD_ASSET_BUCKET_NAME}
 audio_bucket_name=${AUDIO_BUCKET_NAME}
 model_storage_bucket=${MODEL_STORAGE_BUCKET}
 queue_url=${AWS_QUEUE_URL}
+rag_queue_url=${AWS_RAG_QUEUE_URL}
 region=${AWS_REGION}
 
 [gcp]

--- a/wavefront/server/docker/inference_app.Dockerfile
+++ b/wavefront/server/docker/inference_app.Dockerfile
@@ -11,21 +11,18 @@ RUN apt-get update && apt-get install -y \
     libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
 
-COPY wavefront/server/pyproject.toml wavefront/server/uv.lock wavefront/server/.python-version ./
+# Create user early so uv sync runs as appuser — avoids Python binary landing in /root/.local
+RUN useradd -m -u 1000 appuser && chown -R appuser:appuser /app
 
-COPY wavefront/server/modules/common_module /app/modules/common_module
-COPY wavefront/server/packages/flo_cloud /app/packages/flo_cloud
-COPY wavefront/server/apps/inference_app /app/apps/inference_app
+COPY --chown=appuser:appuser wavefront/server/pyproject.toml wavefront/server/uv.lock wavefront/server/.python-version ./
+COPY --chown=appuser:appuser wavefront/server/modules/common_module /app/modules/common_module
+COPY --chown=appuser:appuser wavefront/server/packages/flo_cloud /app/packages/flo_cloud
+COPY --chown=appuser:appuser wavefront/server/apps/inference_app /app/apps/inference_app
+
+USER appuser
 
 RUN uv sync --package inference-app --frozen --no-dev
 
 WORKDIR /app/apps/inference_app/inference_app
-
-# Create a non-root user and change ownership of the /app directory
-RUN useradd -m -u 1000 appuser && \
-    chown -R appuser:appuser /app
-
-# Ensure subsequent actions run as 'appuser'
-USER appuser
 
 CMD ["uv", "run", "server.py"]

--- a/wavefront/server/docker/inference_app.Dockerfile
+++ b/wavefront/server/docker/inference_app.Dockerfile
@@ -21,11 +21,9 @@ RUN uv sync --package inference-app --frozen --no-dev
 
 WORKDIR /app/apps/inference_app/inference_app
 
-# Create a non-root user 'appuser' with a home directory
-RUN useradd -m appuser
-
-# Change ownership of the /app directory to 'appuser' to ensure permission
-RUN chown -R appuser:appuser /app
+# Create a non-root user and change ownership of the /app directory
+RUN useradd -m -u 1000 appuser && \
+    chown -R appuser:appuser /app
 
 # Ensure subsequent actions run as 'appuser'
 USER appuser

--- a/wavefront/server/modules/db_repo_module/db_repo_module/cache/cache_manager.py
+++ b/wavefront/server/modules/db_repo_module/db_repo_module/cache/cache_manager.py
@@ -108,6 +108,12 @@ class CacheManager(CommonCache):
                 'health_check_interval': 30,
                 'encoding': 'utf-8',
                 'decode_responses': True,
+                # Azure Managed Redis drops the connection on CLIENT SETINFO rather
+                # than returning a RESP error, which redis-py 5.x doesn't handle —
+                # the dropped socket triggers a reconnect loop that hits Python's
+                # recursion limit. Empty strings skip the command entirely.
+                'lib_name': '',
+                'lib_version': '',
             }
 
             if cloud_provider == 'azure' and not password:

--- a/wavefront/server/modules/knowledge_base_module/knowledge_base_module/controllers/knowledge_base_document_controller.py
+++ b/wavefront/server/modules/knowledge_base_module/knowledge_base_module/controllers/knowledge_base_document_controller.py
@@ -143,7 +143,7 @@ async def upload_document(
             topic_id = (
                 config['gcp']['email_topic_id']
                 if config['cloud_config']['cloud_provider'] == 'gcp'
-                else config['aws']['queue_url']
+                else config['aws']['rag_queue_url']
             )
             message_id = message_queue.add_message(
                 message_body=data, topic_name_or_queue_url=topic_id

--- a/wavefront/server/packages/flo_cloud/flo_cloud/_types/message_queue.py
+++ b/wavefront/server/packages/flo_cloud/flo_cloud/_types/message_queue.py
@@ -14,7 +14,7 @@ class MessageQueue(ABC):
     @abstractmethod
     def receive_messages(
         self, max_messages: int = 10, wait_time_sec: int = 20
-    ) -> List[MessageQueueDict] | None:
+    ) -> List[MessageQueueDict]:
         """
         Receive messages from the event queue.
 
@@ -23,6 +23,7 @@ class MessageQueue(ABC):
                 - 'body': message content (any type)
                 - 'ack_id': acknowledgement ID (str)
                 - 'id': message ID (str)
+            Empty list if no messages are available; never None.
         """
         pass
 

--- a/wavefront/server/packages/flo_cloud/flo_cloud/aws/sqs.py
+++ b/wavefront/server/packages/flo_cloud/flo_cloud/aws/sqs.py
@@ -14,7 +14,7 @@ class SQSQueue(MessageQueue):
 
     def receive_messages(
         self, max_messages=10, wait_time_sec=20, **kwargs
-    ) -> List[MessageQueueDict] | None:
+    ) -> List[MessageQueueDict]:
         try:
             response = self.sqs_client.receive_message(
                 QueueUrl=self.queue_url,
@@ -23,11 +23,8 @@ class SQSQueue(MessageQueue):
                 VisibilityTimeout=kwargs.get('visibility_timeout', 300),
             )
 
-            if 'Messages' not in response:
-                return None
-
             messages = []
-            for message in response['Messages']:
+            for message in response.get('Messages', []):
                 body = json.loads(message['Body'])
                 messages.append(
                     MessageQueueDict(

--- a/wavefront/server/packages/flo_cloud/flo_cloud/gcp/pubsub.py
+++ b/wavefront/server/packages/flo_cloud/flo_cloud/gcp/pubsub.py
@@ -28,7 +28,7 @@ class PubSubQueue(MessageQueue):
 
     def receive_messages(
         self, max_messages=10, wait_time_sec=20
-    ) -> List[MessageQueueDict] | None:
+    ) -> List[MessageQueueDict]:
         try:
             response = self.subscriber.pull(
                 request={


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated AWS RAG queue setting and wired it into the app’s AWS configuration.
  * Document uploads now route processing requests to the dedicated AWS RAG queue (non-GCP).

* **Bug Fixes**
  * Message polling now consistently returns an empty list when no messages are available (instead of a nullable result) across AWS and Google Cloud.
  * Improved Redis connectivity behavior for Azure Managed Redis to avoid an unwanted reconnect loop.

* **Chores**
  * Updated the inference container build to set up the non-root user and file ownership earlier, and apply correct ownership during copy steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->