### PR TITLE
fix(arium): honor tool prefilled_params via AriumBuilder.from_yaml

### DIFF
--- a/flo_ai/flo_ai/arium/builder.py
+++ b/flo_ai/flo_ai/arium/builder.py
@@ -5,6 +5,7 @@ from flo_ai.arium.nodes import AriumNode, ForEachNode
 from flo_ai.models import BaseMessage, UserMessage
 from flo_ai.agent.agent import Agent, resolve_variables
 from flo_ai.tool.base_tool import Tool
+from flo_ai.tool.tool_config import ToolConfig
 import yaml
 from flo_ai.agent import AgentBuilder
 from flo_ai.llm import BaseLLM
@@ -896,17 +897,38 @@ class AriumBuilder:
                 # Handle both string tool names and ToolConfigModel instances
                 if isinstance(tool_item, str):
                     tool_name = tool_item
+                    prefilled_params = None
+                    name_override = None
+                    description_override = None
                 else:
-                    # ToolConfigModel - extract name
+                    # ToolConfigModel - extract name and pre-filled configuration
                     tool_name = tool_item.name
+                    prefilled_params = tool_item.prefilled_params
+                    name_override = tool_item.name_override
+                    description_override = tool_item.description_override
 
-                if tool_name in available_tools:
-                    agent_tools.append(available_tools[tool_name])
-                else:
+                if tool_name not in available_tools:
                     raise ValueError(
                         f'Tool {tool_name} for agent {name} not found in available tools. '
                         f'Available: {list(available_tools.keys())}'
                     )
+
+                base_tool = available_tools[tool_name]
+                if prefilled_params or name_override or description_override:
+                    # Wrap in a PartialTool so prefilled_params (e.g. kb_id,
+                    # datasource_id) are hidden from the model and locked to
+                    # the configured value, instead of being left as regular,
+                    # model-suppliable parameters.
+                    agent_tools.append(
+                        ToolConfig(
+                            tool=base_tool,
+                            prefilled_params=prefilled_params,
+                            name_override=name_override,
+                            description_override=description_override,
+                        ).to_tool()
+                    )
+                else:
+                    agent_tools.append(base_tool)
 
         # Handle parser configuration if present
         output_schema: Optional[Dict[str, Any]] = None

--- a/flo_ai/flo_ai/tool/partial_tool.py
+++ b/flo_ai/flo_ai/tool/partial_tool.py
@@ -45,9 +45,14 @@ class PartialTool(Tool):
     async def execute(self, **kwargs) -> Any:
         """Execute the tool with pre-filled parameters merged with AI-provided ones."""
         try:
-            # Merge pre-filled params with AI-provided params
-            # AI params take precedence over pre-filled ones
-            merged_params = {**self.prefilled_params, **kwargs}
+            # Merge pre-filled params with AI-provided params.
+            # Pre-filled params always win: they are deliberately stripped from
+            # the parameter schema shown to the model (see __init__ above), so
+            # they must not be overridable by anything the model returns —
+            # including keys the model emits that aren't even in its schema
+            # (a real occurrence, not hypothetical: some providers/reasoning
+            # loops return extra keys beyond the declared parameters).
+            merged_params = {**kwargs, **self.prefilled_params}
 
             logger.info(
                 f'Executing partial tool {self.name} with merged params: {merged_params}'

--- a/flo_ai/tests/unit-tests/test_partial_tool.py
+++ b/flo_ai/tests/unit-tests/test_partial_tool.py
@@ -119,8 +119,15 @@ class TestPartialTool:
         assert result == 'test_result'
 
     @pytest.mark.asyncio
-    async def test_partial_tool_execution_ai_params_override_prefilled(self):
-        """Test that AI-provided parameters override pre-filled ones."""
+    async def test_partial_tool_execution_prefilled_params_override_ai(self):
+        """Test that pre-filled parameters always win over AI-provided ones.
+
+        Pre-filled params are deliberately stripped from the schema shown to
+        the model (see PartialTool.__init__), so they must not be
+        overridable by anything the model returns — including keys the
+        model emits that aren't even in its declared schema, which some
+        providers/reasoning loops do in practice.
+        """
         mock_function = AsyncMock(return_value='test_result')
         base_tool = Tool(
             name='test_tool',
@@ -144,16 +151,18 @@ class TestPartialTool:
             base_tool=base_tool, prefilled_params={'datasource_id': 'ds_123'}
         )
 
-        # Execute with AI-provided datasource_id that should override pre-filled one
+        # Execute with an AI-provided datasource_id that must NOT override
+        # the pre-filled one, even though datasource_id was stripped from
+        # the schema shown to the model (partial_tool.parameters).
         await partial_tool.execute(
             query='SELECT * FROM users',
-            datasource_id='ds_456',  # This should override the pre-filled "ds_123"
+            datasource_id='ds_456',  # attempted override, must be ignored
         )
 
-        # Verify the function was called with AI-provided datasource_id
+        # Verify the function was called with the pre-filled datasource_id
         mock_function.assert_called_once_with(
             query='SELECT * FROM users',
-            datasource_id='ds_456',  # AI-provided value should take precedence
+            datasource_id='ds_123',  # pre-filled value must take precedence
         )
 
     def test_partial_tool_parameter_management(self):


### PR DESCRIPTION

Two related bugs let a model override "hidden" tool parameters (e.g. kb_id, datasource_id) that prefilled_params was supposed to lock:

1. arium/builder.py: _create_agent_from_direct_config resolved tools by name only, ignoring prefilled_params/name_override/description_override on ToolConfigModel entries entirely — so PartialTool was never constructed for agents defined inline inside an arium: block, unlike AgentBuilder.from_yaml which already handled this correctly. This was the actual root cause: every prefilled_params value on an inline arium agent's tool was silently a no-op.

2. tool/partial_tool.py: PartialTool.execute() merged {**prefilled_params, **kwargs}, so any key the model returned — even one outside its declared schema, which some providers/reasoning loops do return — would override the corresponding prefilled value. Flipped to {**kwargs, **prefilled_params} so prefilled values always win, since they're deliberately stripped from the schema shown to the model and were never meant to be model-suppliable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for richer tool configurations, including prefilled parameters, custom names, and custom descriptions.
  * Tool configurations can now lock provided fields so they cannot be overridden during execution.
* **Bug Fixes**
  * Prefilled tool parameters now consistently take precedence over parameters supplied by the AI.
* **Tests**
  * Updated unit tests to reflect the new prefilled-parameter precedence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->