### PR TITLE
adding clip and dinov3 models to cloudbucket instead of downloading from hf

### DIFF
--- a/wavefront/server/apps/inference_app/inference_app/env.py
+++ b/wavefront/server/apps/inference_app/inference_app/env.py
@@ -1,0 +1,11 @@
+import os
+
+CLOUD_PROVIDER = os.getenv("CLOUD_PROVIDER", "")
+
+# HF model: openai/clip-vit-base-patch32
+CLIP_VIT_BASE_PATCH32_MODEL_URI = os.getenv("CLIP_VIT_BASE_PATCH32_MODEL_URI", "")
+
+# HF model: facebook/dinov3-vitl16-pretrain-lvd1689m
+DINOV3_VITL16_HF_MODEL_URI = os.getenv("DINOV3_VITL16_HF_MODEL_URI", "")
+
+MODEL_CACHE_DIR = os.getenv("MODEL_CACHE_DIR", "/tmp/model-cache")

--- a/wavefront/server/apps/inference_app/inference_app/inference_app_container.py
+++ b/wavefront/server/apps/inference_app/inference_app/inference_app_container.py
@@ -4,6 +4,13 @@ from inference_app.service.image_embedding import ImageEmbedding
 
 
 class InferenceAppContainer(containers.DeclarativeContainer):
+    """DI container for inference_app.
+
+    image_embedding is declared here as a Singleton placeholder.
+    At startup (server.py lifespan) it is overridden with the actual
+    clip_model_dir / dino_model_dir paths returned by sync_embedding_models().
+    """
+
     config = providers.Configuration(ini_files=['config.ini'])
 
     image_embedding = providers.Singleton(ImageEmbedding)

--- a/wavefront/server/apps/inference_app/inference_app/model_sync.py
+++ b/wavefront/server/apps/inference_app/inference_app/model_sync.py
@@ -1,0 +1,165 @@
+"""Sync Hugging Face-style model folders from cloud blob storage to a local cache.
+
+Mirrors the pattern in packages/utility/utility/model_resolver.py but is
+self-contained inside inference_app so it has no cross-repo dependency.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+from pathlib import Path
+
+from flo_cloud.cloud_storage import CloudStorageManager
+from common_module.log.logger import logger
+
+_CLOUD_URI_PATTERN = re.compile(
+    r"^(?:gs://|s3://|azure://).+",
+    re.IGNORECASE,
+)
+
+CLOUD_PROVIDER = os.getenv("CLOUD_PROVIDER", "")
+CLIP_MODEL_URI = os.getenv("CLIP_MODEL_URI", "")
+DINO_MODEL_URI = os.getenv("DINO_MODEL_URI", "")
+MODEL_CACHE_DIR = os.getenv("MODEL_CACHE_DIR", "/tmp/model-cache")
+
+
+def is_cloud_uri(uri: str) -> bool:
+    """Return True if *uri* is a supported cloud storage URI (gs://, s3://, azure://)."""
+    return bool(_CLOUD_URI_PATTERN.match(uri.strip()))
+
+
+def _cache_key(uri: str) -> str:
+    return hashlib.sha256(uri.strip().encode()).hexdigest()[:16]
+
+
+def _list_all_keys(
+    storage: CloudStorageManager,
+    bucket_name: str,
+    prefix: str,
+    *,
+    page_size: int = 100,
+) -> list[str]:
+    keys: list[str] = []
+    page_number = 1
+    while True:
+        batch, has_next = storage.list_files(
+            bucket_name, prefix, page_size=page_size, page_number=page_number
+        )
+        keys.extend(batch)
+        if not has_next:
+            break
+        page_number += 1
+    return keys
+
+
+def sync_cloud_model(uri: str, *, provider: str, cache_root: Path) -> Path:
+    """
+    Download all objects under a cloud URI prefix into a local cache directory.
+
+    Skips download if a .sync_complete marker already exists (cache hit).
+
+    Args:
+        uri: Cloud URI (gs://, s3://, or azure://container/prefix/).
+        provider: Cloud provider string passed to CloudStorageManager (gcp, aws, azure).
+        cache_root: Parent directory for cached model folders.
+
+    Returns:
+        Path to the local directory containing the synced model files.
+
+    Raises:
+        ValueError: If *uri* is not a cloud URI or the prefix lists no objects.
+    """
+    uri = uri.strip()
+    if not is_cloud_uri(uri):
+        raise ValueError(
+            f"Model URI must be a cloud URI (gs://, s3://, or azure://); got {uri!r}"
+        )
+
+    storage = CloudStorageManager(provider)
+    bucket_name, prefix = storage.get_bucket_key(uri)
+    if prefix and not prefix.endswith("/"):
+        prefix = f"{prefix}/"
+
+    dest_dir = cache_root / _cache_key(uri)
+    marker = dest_dir / ".sync_complete"
+    if marker.is_file():
+        logger.info("Using cached model at %s (uri=%s)", dest_dir, uri)
+        return dest_dir
+
+    logger.info(
+        "Syncing model from %s (bucket=%s, prefix=%s) -> %s",
+        uri,
+        bucket_name,
+        prefix,
+        dest_dir,
+    )
+
+    keys = _list_all_keys(storage, bucket_name, prefix)
+    if not keys:
+        raise ValueError(f"No objects found at cloud URI {uri!r}")
+
+    for key in keys:
+        if key.endswith("/"):
+            continue
+        relative = key[len(prefix):] if prefix and key.startswith(prefix) else key
+        if not relative:
+            continue
+        local_path = dest_dir / relative
+        local_path.parent.mkdir(parents=True, exist_ok=True)
+        local_path.write_bytes(storage.read_file(bucket_name, key))
+        logger.debug("Downloaded %s", relative)
+
+    marker.write_text(uri, encoding="utf-8")
+    logger.info("Synced %d object(s) to %s", len(keys), dest_dir)
+    return dest_dir
+
+
+def _require_cloud_uri(name: str, uri: str) -> str:
+    if not uri:
+        raise ValueError(f"{name} env var is required but not set")
+    if not is_cloud_uri(uri):
+        raise ValueError(
+            f"{name} must be a cloud URI (gs://, s3://, or azure://); got {uri!r}"
+        )
+    return uri
+
+
+def _validate_cloud_config() -> None:
+    if not CLOUD_PROVIDER:
+        raise ValueError("CLOUD_PROVIDER env var is required but not set")
+    _require_cloud_uri("CLIP_MODEL_URI", CLIP_MODEL_URI)
+    _require_cloud_uri("DINO_MODEL_URI", DINO_MODEL_URI)
+
+
+def _ensure_cache_dir() -> Path:
+    cache_root = Path(MODEL_CACHE_DIR)
+    cache_root.mkdir(parents=True, exist_ok=True)
+    return cache_root
+
+
+def _sync_clip(cache_root: Path) -> Path:
+    return sync_cloud_model(CLIP_MODEL_URI, provider=CLOUD_PROVIDER, cache_root=cache_root)
+
+
+def _sync_dino(cache_root: Path) -> Path:
+    return sync_cloud_model(DINO_MODEL_URI, provider=CLOUD_PROVIDER, cache_root=cache_root)
+
+
+def sync_embedding_models() -> tuple[Path, Path]:
+    """
+    Validate env vars, ensure cache dir, and sync CLIP + DINO from cloud storage.
+
+    Returns:
+        (clip_model_dir, dino_model_dir) — local synced directories ready for
+        from_pretrained().
+
+    Raises:
+        ValueError: If required env vars are missing or not valid cloud URIs.
+    """
+    _validate_cloud_config()
+    cache_root = _ensure_cache_dir()
+    clip_dir = _sync_clip(cache_root)
+    dino_dir = _sync_dino(cache_root)
+    return clip_dir, dino_dir

--- a/wavefront/server/apps/inference_app/inference_app/model_sync.py
+++ b/wavefront/server/apps/inference_app/inference_app/model_sync.py
@@ -1,28 +1,32 @@
-"""Sync Hugging Face-style model folders from cloud blob storage to a local cache.
+"""Resolve and sync model directories for CLIP and DINOv3.
 
-Mirrors the pattern in packages/utility/utility/model_resolver.py but is
-self-contained inside inference_app so it has no cross-repo dependency.
+Each model source (CLIP_VIT_BASE_PATCH32_MODEL_URI, DINOV3_VITL16_HF_MODEL_URI) can be:
+- A cloud URI (gs://, s3://, azure://) — synced to MODEL_CACHE_DIR on startup.
+- A local directory path — used directly with no download.
+
+Cloud sync is skipped when a .sync_complete marker exists in the cache dir.
 """
 
 from __future__ import annotations
 
 import hashlib
-import os
 import re
 from pathlib import Path
 
 from flo_cloud.cloud_storage import CloudStorageManager
 from common_module.log.logger import logger
 
+from inference_app.env import (
+    CLOUD_PROVIDER,
+    CLIP_VIT_BASE_PATCH32_MODEL_URI,
+    DINOV3_VITL16_HF_MODEL_URI,
+    MODEL_CACHE_DIR,
+)
+
 _CLOUD_URI_PATTERN = re.compile(
     r"^(?:gs://|s3://|azure://).+",
     re.IGNORECASE,
 )
-
-CLOUD_PROVIDER = os.getenv("CLOUD_PROVIDER", "")
-CLIP_MODEL_URI = os.getenv("CLIP_MODEL_URI", "")
-DINO_MODEL_URI = os.getenv("DINO_MODEL_URI", "")
-MODEL_CACHE_DIR = os.getenv("MODEL_CACHE_DIR", "/tmp/model-cache")
 
 
 def is_cloud_uri(uri: str) -> bool:
@@ -116,21 +120,45 @@ def sync_cloud_model(uri: str, *, provider: str, cache_root: Path) -> Path:
     return dest_dir
 
 
-def _require_cloud_uri(name: str, uri: str) -> str:
+def resolve_model_dir(name: str, uri: str, cache_root: Path) -> Path:
+    """
+    Resolve a model source to a local directory.
+
+    Accepts:
+    - Cloud URI (gs://, s3://, azure://) — downloads to cache_root and returns
+      the local dir. Skips download if .sync_complete already exists.
+    - Local directory path — returned directly with no download.
+
+    Args:
+        name: Env var name, used in error messages.
+        uri: Cloud URI or local path string.
+        cache_root: Parent directory for synced model folders (used for cloud only).
+
+    Returns:
+        Path to a local directory ready for from_pretrained().
+
+    Raises:
+        ValueError: If uri is empty, not a cloud URI, and not an existing local dir.
+    """
     if not uri:
         raise ValueError(f"{name} env var is required but not set")
-    if not is_cloud_uri(uri):
-        raise ValueError(
-            f"{name} must be a cloud URI (gs://, s3://, or azure://); got {uri!r}"
-        )
-    return uri
 
+    if is_cloud_uri(uri):
+        if not CLOUD_PROVIDER:
+            raise ValueError(
+                "CLOUD_PROVIDER env var is required when using a cloud URI"
+            )
+        return sync_cloud_model(uri, provider=CLOUD_PROVIDER, cache_root=cache_root)
 
-def _validate_cloud_config() -> None:
-    if not CLOUD_PROVIDER:
-        raise ValueError("CLOUD_PROVIDER env var is required but not set")
-    _require_cloud_uri("CLIP_MODEL_URI", CLIP_MODEL_URI)
-    _require_cloud_uri("DINO_MODEL_URI", DINO_MODEL_URI)
+    local = Path(uri)
+    if local.is_dir():
+        logger.info("Using local model dir for %s: %s", name, local)
+        return local
+
+    raise ValueError(
+        f"{name}={uri!r} is neither a cloud URI (gs://, s3://, azure://)"
+        f" nor an existing local directory"
+    )
 
 
 def _ensure_cache_dir() -> Path:
@@ -139,27 +167,20 @@ def _ensure_cache_dir() -> Path:
     return cache_root
 
 
-def _sync_clip(cache_root: Path) -> Path:
-    return sync_cloud_model(CLIP_MODEL_URI, provider=CLOUD_PROVIDER, cache_root=cache_root)
-
-
-def _sync_dino(cache_root: Path) -> Path:
-    return sync_cloud_model(DINO_MODEL_URI, provider=CLOUD_PROVIDER, cache_root=cache_root)
-
-
 def sync_embedding_models() -> tuple[Path, Path]:
     """
-    Validate env vars, ensure cache dir, and sync CLIP + DINO from cloud storage.
+    Resolve CLIP and DINO model directories from env vars.
+
+    Each URI can be a cloud URI (gs://, s3://, azure://) or a local directory path.
+    Cloud sources are synced to MODEL_CACHE_DIR; local paths are used directly.
 
     Returns:
-        (clip_model_dir, dino_model_dir) — local synced directories ready for
-        from_pretrained().
+        (clip_model_dir, dino_model_dir) — local directories ready for from_pretrained().
 
     Raises:
-        ValueError: If required env vars are missing or not valid cloud URIs.
+        ValueError: If required env vars are missing or point to invalid sources.
     """
-    _validate_cloud_config()
     cache_root = _ensure_cache_dir()
-    clip_dir = _sync_clip(cache_root)
-    dino_dir = _sync_dino(cache_root)
+    clip_dir = resolve_model_dir("CLIP_VIT_BASE_PATCH32_MODEL_URI", CLIP_VIT_BASE_PATCH32_MODEL_URI, cache_root)
+    dino_dir = resolve_model_dir("DINOV3_VITL16_HF_MODEL_URI", DINOV3_VITL16_HF_MODEL_URI, cache_root)
     return clip_dir, dino_dir

--- a/wavefront/server/apps/inference_app/inference_app/server.py
+++ b/wavefront/server/apps/inference_app/inference_app/server.py
@@ -1,6 +1,7 @@
 import glob
 import os
 from contextlib import asynccontextmanager
+from dependency_injector import providers
 
 from dotenv import load_dotenv
 from fastapi import FastAPI
@@ -20,6 +21,8 @@ from fastapi.responses import JSONResponse
 
 from inference_app.inference_app_container import InferenceAppContainer
 from inference_app.controllers.inference_controller import inference_app_router
+from inference_app.model_sync import sync_embedding_models
+from inference_app.service.image_embedding import ImageEmbedding
 
 # Initialize dependency containers
 common_container = CommonContainer(cache_manager=None)
@@ -28,7 +31,12 @@ inference_app_container = InferenceAppContainer()
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    logger.info('Preloading ML models...')
+    logger.info('Syncing embedding models from cloud storage...')
+    clip_dir, dino_dir = sync_embedding_models()
+    logger.info('Cloud sync complete. Preloading ML models...')
+    inference_app_container.image_embedding.override(
+        providers.Singleton(ImageEmbedding, clip_model_dir=clip_dir, dino_model_dir=dino_dir)
+    )
     inference_app_container.image_embedding()
     logger.info('ML models loaded and ready.')
     yield

--- a/wavefront/server/apps/inference_app/inference_app/service/image_embedding.py
+++ b/wavefront/server/apps/inference_app/inference_app/service/image_embedding.py
@@ -1,28 +1,41 @@
 import torch
+from pathlib import Path
 from transformers import CLIPProcessor, CLIPModel, AutoImageProcessor, AutoModel
 from PIL import Image
 import io
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Union
 from common_module.log.logger import logger
-
-CLIP_MODEL_NAME = 'openai/clip-vit-base-patch32'
-DINO_MODEL_NAME = 'facebook/dinov3-vitl16-pretrain-lvd1689m'
 
 
 class ImageEmbedding:
-    def __init__(self):
+    """
+    Loads CLIP and DINOv3 models from local synced directories.
+
+    Both model dirs must be full Hugging Face snapshots (from_pretrained-compatible).
+    Use model_sync.sync_embedding_models() to sync from cloud storage before
+    constructing this class.
+    """
+
+    def __init__(
+        self,
+        clip_model_dir: Union[str, Path],
+        dino_model_dir: Union[str, Path],
+    ):
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         logger.info(f'Using device: {self.device}')
 
-        self.clip_processor = CLIPProcessor.from_pretrained(CLIP_MODEL_NAME)
-        self.clip_model = CLIPModel.from_pretrained(CLIP_MODEL_NAME).to(
-            self.device
-        )
+        clip_path = str(Path(clip_model_dir))
+        dino_path = str(Path(dino_model_dir))
+
+        logger.info('Loading CLIP model from %s', clip_path)
+        self.clip_processor = CLIPProcessor.from_pretrained(clip_path)
+        self.clip_model = CLIPModel.from_pretrained(clip_path).to(self.device)
         self.clip_model.eval()
 
-        self.dino_processor = AutoImageProcessor.from_pretrained(DINO_MODEL_NAME)
+        logger.info('Loading DINOv3 model from %s', dino_path)
+        self.dino_processor = AutoImageProcessor.from_pretrained(dino_path)
         self.dino_model = AutoModel.from_pretrained(
-            DINO_MODEL_NAME, trust_remote_code=True
+            dino_path, trust_remote_code=True
         ).to(self.device)
         self.dino_model.eval()
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic synchronization of CLIP and DINO embedding models from supported cloud storage with local caching.
  * The inference service now initializes embedding models from synchronized local model snapshots at startup.
* **Refactor**
  * Updated the embedding loader to accept local CLIP/DINO model directories instead of relying on fixed model identifiers.
* **Bug Fixes**
  * Added validation for cloud URI schemes and required cloud configuration, with clearer errors for unsupported/empty sources.
* **Documentation**
  * Improved inline documentation for the inference app container and model synchronization flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->