### PR TITLE
allow agent workflow name to start with number

### DIFF
--- a/wavefront/server/modules/agents_module/agents_module/utils/validation_utils.py
+++ b/wavefront/server/modules/agents_module/agents_module/utils/validation_utils.py
@@ -4,7 +4,7 @@ import re
 def validate_agent_workflow_name(name: str, type: str = 'agent') -> None:
     """
     Validate agent or workflow name to ensure it:
-    - Starts with a letter (a-z, A-Z)
+    - Starts with a letter or number (a-z, A-Z, 0-9)
     - Contains only letters, numbers, hyphens, and underscores
     - No spaces or special characters
 
@@ -18,11 +18,11 @@ def validate_agent_workflow_name(name: str, type: str = 'agent') -> None:
     if not name:
         raise ValueError(f'{type.capitalize()} name cannot be empty')
 
-    # Must start with a letter, followed by letters, numbers, hyphens, or underscores
-    pattern = r'^[a-zA-Z][a-zA-Z0-9_-]*$'
+    # Must start with a letter or number, followed by letters, numbers, hyphens, or underscores
+    pattern = r'^[a-zA-Z0-9][a-zA-Z0-9_-]*$'
 
     if not re.match(pattern, name):
         raise ValueError(
-            f'{type.capitalize()} name must start with a letter and can only contain letters, numbers, '
+            f'{type.capitalize()} name must start with a letter or number and can only contain letters, numbers, '
             'hyphens, and underscores. Spaces and special characters are not allowed.'
         )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Agent and workflow names can now begin with a letter or number.
  * Updated validation messaging to reflect the expanded naming rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->