### PR TITLE
add transactional multi-table insert for postgres datasources

### DIFF
--- a/wavefront/server/modules/plugins_module/plugins_module/controllers/datasource_controller.py
+++ b/wavefront/server/modules/plugins_module/plugins_module/controllers/datasource_controller.py
@@ -28,6 +28,7 @@ from plugins_module.services.datasource_services import (
     validate_datasource_payload,
 )
 from plugins_module.utils.helper import (
+    InsertRowsJsonMultiPayload,
     AddDatasourcePayload,
     UpdateDatasourcePayload,
     InsertRowsJsonPayload,
@@ -537,6 +538,62 @@ async def insert_rows_json(
         content=response_formatter.buildSuccessResponse(
             {
                 'message': f'Inserted {len(insert_rows_json_payload.data)} rows successfully'
+            }
+        ),
+    )
+
+
+@datasource_router.post('/v1/datasources/{datasource_id}/resources')
+@inject
+async def insert_rows_json_multi(
+    request: Request,
+    datasource_id: str,
+    insert_rows_json_multi_payload: InsertRowsJsonMultiPayload,
+    response_formatter: ResponseFormatter = Depends(
+        Provide[CommonContainer.response_formatter]
+    ),
+):
+    """Insert rows into multiple tables of one datasource atomically.
+
+    All tables are written in a single transaction (all-or-nothing). Currently
+    only Postgres supports this; other datasource types return 501.
+    """
+    datasource_type, datasource_config = await get_datasource_config(datasource_id)
+    if not datasource_config:
+        return JSONResponse(
+            status_code=status.HTTP_404_NOT_FOUND,
+            content=response_formatter.buildErrorResponse(
+                f'Datasource not found: {datasource_id}'
+            ),
+        )
+
+    datasource_plugin = DatasourcePlugin(datasource_type, datasource_config)
+
+    prepared = []
+    for insert in insert_rows_json_multi_payload.inserts:
+        rows = [insert.data] if insert.single_row else insert.data
+        rows_with_created_at = [
+            {**row, 'created_at': datetime.now().isoformat()} for row in rows
+        ]
+        prepared.append({'table_name': insert.table_name, 'data': rows_with_created_at})
+
+    try:
+        datasource_plugin.insert_rows_json_multi(prepared)
+    except NotImplementedError as e:
+        return JSONResponse(
+            status_code=status.HTTP_501_NOT_IMPLEMENTED,
+            content=response_formatter.buildErrorResponse(str(e)),
+        )
+
+    total_rows = sum(len(p['data']) for p in prepared)
+    return JSONResponse(
+        status_code=status.HTTP_200_OK,
+        content=response_formatter.buildSuccessResponse(
+            {
+                'message': (
+                    f'Inserted {total_rows} rows across '
+                    f'{len(prepared)} table(s) successfully'
+                )
             }
         ),
     )

--- a/wavefront/server/modules/plugins_module/plugins_module/controllers/datasource_controller.py
+++ b/wavefront/server/modules/plugins_module/plugins_module/controllers/datasource_controller.py
@@ -508,45 +508,7 @@ async def query_datasource(
     )
 
 
-@datasource_router.post('/v1/datasources/{datasource_id}/resources/{resource_id}')
-@inject
-async def insert_rows_json(
-    request: Request,
-    datasource_id: str,
-    resource_id: str,
-    insert_rows_json_payload: InsertRowsJsonPayload,
-    response_formatter: ResponseFormatter = Depends(
-        Provide[CommonContainer.response_formatter]
-    ),
-):
-    datasource_type, datasource_config = await get_datasource_config(datasource_id)
-    if not datasource_config:
-        return JSONResponse(
-            status_code=status.HTTP_404_NOT_FOUND,
-            content=response_formatter.buildErrorResponse(
-                f'Datasource not found: {datasource_id}'
-            ),
-        )
-
-    datasource_plugin = DatasourcePlugin(datasource_type, datasource_config)
-    rows_with_created_at = [
-        {**row, 'created_at': datetime.now().isoformat()}
-        for row in insert_rows_json_payload.data
-    ]
-    await asyncio.to_thread(
-        datasource_plugin.insert_rows_json, resource_id, rows_with_created_at
-    )
-    return JSONResponse(
-        status_code=status.HTTP_200_OK,
-        content=response_formatter.buildSuccessResponse(
-            {
-                'message': f'Inserted {len(insert_rows_json_payload.data)} rows successfully'
-            }
-        ),
-    )
-
-
-@datasource_router.post('/v1/datasources/{datasource_id}/resources')
+@datasource_router.post('/v1/datasources/{datasource_id}/resources/insert')
 @inject
 async def insert_rows_json_multi(
     request: Request,
@@ -597,6 +559,44 @@ async def insert_rows_json_multi(
                     f'Inserted {total_rows} rows across '
                     f'{len(prepared)} table(s) successfully'
                 )
+            }
+        ),
+    )
+
+
+@datasource_router.post('/v1/datasources/{datasource_id}/resources/{resource_id}')
+@inject
+async def insert_rows_json(
+    request: Request,
+    datasource_id: str,
+    resource_id: str,
+    insert_rows_json_payload: InsertRowsJsonPayload,
+    response_formatter: ResponseFormatter = Depends(
+        Provide[CommonContainer.response_formatter]
+    ),
+):
+    datasource_type, datasource_config = await get_datasource_config(datasource_id)
+    if not datasource_config:
+        return JSONResponse(
+            status_code=status.HTTP_404_NOT_FOUND,
+            content=response_formatter.buildErrorResponse(
+                f'Datasource not found: {datasource_id}'
+            ),
+        )
+
+    datasource_plugin = DatasourcePlugin(datasource_type, datasource_config)
+    rows_with_created_at = [
+        {**row, 'created_at': datetime.now().isoformat()}
+        for row in insert_rows_json_payload.data
+    ]
+    await asyncio.to_thread(
+        datasource_plugin.insert_rows_json, resource_id, rows_with_created_at
+    )
+    return JSONResponse(
+        status_code=status.HTTP_200_OK,
+        content=response_formatter.buildSuccessResponse(
+            {
+                'message': f'Inserted {len(insert_rows_json_payload.data)} rows successfully'
             }
         ),
     )

--- a/wavefront/server/modules/plugins_module/plugins_module/controllers/datasource_controller.py
+++ b/wavefront/server/modules/plugins_module/plugins_module/controllers/datasource_controller.py
@@ -4,6 +4,7 @@ from datasource.redshift.config import RedshiftConfig
 from datasource.postgres.config import PostgresConfig
 from datasource.mssql.config import MSSQLConfig
 from dependency_injector.wiring import inject
+import asyncio
 import json
 from dependency_injector.wiring import Provide
 from fastapi import Depends
@@ -532,7 +533,9 @@ async def insert_rows_json(
         {**row, 'created_at': datetime.now().isoformat()}
         for row in insert_rows_json_payload.data
     ]
-    datasource_plugin.insert_rows_json(resource_id, rows_with_created_at)
+    await asyncio.to_thread(
+        datasource_plugin.insert_rows_json, resource_id, rows_with_created_at
+    )
     return JSONResponse(
         status_code=status.HTTP_200_OK,
         content=response_formatter.buildSuccessResponse(
@@ -578,7 +581,7 @@ async def insert_rows_json_multi(
         prepared.append({'table_name': insert.table_name, 'data': rows_with_created_at})
 
     try:
-        datasource_plugin.insert_rows_json_multi(prepared)
+        await asyncio.to_thread(datasource_plugin.insert_rows_json_multi, prepared)
     except NotImplementedError as e:
         return JSONResponse(
             status_code=status.HTTP_501_NOT_IMPLEMENTED,

--- a/wavefront/server/modules/plugins_module/plugins_module/utils/helper.py
+++ b/wavefront/server/modules/plugins_module/plugins_module/utils/helper.py
@@ -22,6 +22,17 @@ class InsertRowsJsonPayload(BaseModel):
     data: List[Dict[str, Any]]
 
 
+class TableInsert(BaseModel):
+    table_name: str
+    # A single row dict if single_row=True, otherwise a list of row dicts.
+    data: Any
+    single_row: bool = False
+
+
+class InsertRowsJsonMultiPayload(BaseModel):
+    inserts: List[TableInsert]
+
+
 class DynamicQueryRequest(BaseModel):
     dynamic_query: str
 

--- a/wavefront/server/modules/tools_module/tools_module/available_tools.json
+++ b/wavefront/server/modules/tools_module/tools_module/available_tools.json
@@ -29,6 +29,27 @@
     ],
     "category": "datasource"
   },
+  "datasource_insert_multi": {
+    "name": "datasource_insert_multi",
+    "description": "Insert rows into MULTIPLE tables of one datasource atomically, in a single all-or-nothing transaction (any failure rolls back every table). Currently supported for Postgres datasources only. Returns a descriptive string confirming success or detailing any errors.",
+    "parameters": {
+      "datasource_id": {
+        "type": "string",
+        "description": "UUID of the configured datasource"
+      },
+      "inserts": {
+        "type": "TYPE_UNSPECIFIED",
+        "description": "An array of per-table insert specs. Each item is an object {\"table_name\": string, \"data\": row-or-rows, \"single_row\": boolean}. 'data' is a single row object when single_row is true, otherwise an array of row objects. All tables are written in one transaction, so order parents before children for FK constraints."
+      }
+    },
+    "prefill_values": [
+      "datasource_id"
+    ],
+    "required": [
+      "inserts"
+    ],
+    "category": "datasource"
+  },
   "querying_knowlegebase": {
     "name": "querying_knowlegebase",
     "description": "Query the knowlegebase using the configured datasource. Returns a descriptive string indicating success or failure with connection details.",

--- a/wavefront/server/modules/tools_module/tools_module/datasources/datasource_api_tools.py
+++ b/wavefront/server/modules/tools_module/tools_module/datasources/datasource_api_tools.py
@@ -37,3 +37,41 @@ async def datasource_insert_rows(
         return f'Insert failed ({response.status_code}): {response.text}'
 
     return f"Inserted {len(rows)} row(s) into '{table_name}' via datasource '{datasource_id}'"
+
+
+async def datasource_insert_multi(datasource_id: str, inserts) -> str:
+    """Insert rows into MULTIPLE tables of one datasource atomically (a single
+    transaction — all-or-nothing) via wavefront's own REST API
+    (POST /v1/datasources/{datasource_id}/resources).
+
+    inserts: a list of per-table specs, each
+        {"table_name": str, "data": <single row dict or list of row dicts>,
+         "single_row": bool (optional, default false)}.
+
+    All tables are written in one DB transaction: any failure rolls back every
+    table. Currently only Postgres datasources support this; others return 501.
+    """
+    url = (
+        f'{FLOWARE_BASE_URL}/floware/v1/datasources/'
+        f'{quote(datasource_id, safe="")}/resources'
+    )
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.post(
+                url,
+                json={'inserts': inserts},
+                timeout=30.0,
+            )
+        except httpx.RequestError as e:
+            return f"Failed to reach datasource API for '{datasource_id}': {e}"
+
+    if response.status_code == 404:
+        return f"Datasource '{datasource_id}' not found"
+    if response.status_code != 200:
+        return f'Multi-insert failed ({response.status_code}): {response.text}'
+
+    table_count = len(inserts) if isinstance(inserts, list) else 0
+    return (
+        f"Inserted into {table_count} table(s) via datasource '{datasource_id}' "
+        '(transactional)'
+    )

--- a/wavefront/server/modules/tools_module/tools_module/datasources/datasource_api_tools.py
+++ b/wavefront/server/modules/tools_module/tools_module/datasources/datasource_api_tools.py
@@ -42,7 +42,7 @@ async def datasource_insert_rows(
 async def datasource_insert_multi(datasource_id: str, inserts) -> str:
     """Insert rows into MULTIPLE tables of one datasource atomically (a single
     transaction — all-or-nothing) via wavefront's own REST API
-    (POST /v1/datasources/{datasource_id}/resources).
+    (POST /v1/datasources/{datasource_id}/resources/insert).
 
     inserts: a list of per-table specs, each
         {"table_name": str, "data": <single row dict or list of row dicts>,
@@ -53,7 +53,7 @@ async def datasource_insert_multi(datasource_id: str, inserts) -> str:
     """
     url = (
         f'{FLOWARE_BASE_URL}/floware/v1/datasources/'
-        f'{quote(datasource_id, safe="")}/resources'
+        f'{quote(datasource_id, safe="")}/resources/insert'
     )
     async with httpx.AsyncClient() as client:
         try:

--- a/wavefront/server/modules/tools_module/tools_module/registry/registries/datasource_registry.py
+++ b/wavefront/server/modules/tools_module/tools_module/registry/registries/datasource_registry.py
@@ -8,9 +8,11 @@ appropriate datasource plugin (Postgres/BigQuery/Redshift/MSSQL) internally.
 
 from tools_module.datasources.datasource_api_tools import (
     datasource_insert_rows,
+    datasource_insert_multi,
 )
 
 # Combined datasource registry
 DATASOURCE_REGISTRY = {
     'datasource_insert_rows': datasource_insert_rows,
+    'datasource_insert_multi': datasource_insert_multi,
 }

--- a/wavefront/server/modules/tools_module/tools_module/utils/message_processor_fn.py
+++ b/wavefront/server/modules/tools_module/tools_module/utils/message_processor_fn.py
@@ -1,33 +1,54 @@
 import json
-from plugins_module.controllers.message_processor_controller import (
-    execute_message_processor,
-    ExecuteMessageProcessorPayload,
-)
+import os
+
+import httpx
+
+FLOWARE_BASE_URL = os.getenv('FLOWARE_BASE_URL', 'http://localhost:8001').rstrip('/')
 
 
 async def execute_message_processor_fn(message_processor_id: str, **kwargs) -> str:
-    """Execute a message processor function
+    """Execute a deployed message processor via wavefront's own REST API
+    (POST /v1/message-processors/{processor_id}/execute).
 
     Args:
         message_processor_id: UUID of the message processor to execute
-        **kwargs: Dynamic parameters based on processor's input_schema
+        **kwargs: Dynamic parameters based on the processor's input_schema
 
     Returns:
         Result from message processor execution as string
     """
-    # Remove message_processor_id from kwargs (it's not part of input_data)
+    # Everything except the processor id is the processor's input_data. The
+    # function-node adapter passes the actual inputs under a 'kwargs' key; fall
+    # back to the flat params if that key isn't present.
     input_data = {k: v for k, v in kwargs.items() if k != 'message_processor_id'}
+    processor_input = input_data.get('kwargs', input_data)
 
-    payload = ExecuteMessageProcessorPayload(input_data=input_data['kwargs'])
-    response = await execute_message_processor(message_processor_id, payload)
+    url = (
+        f'{FLOWARE_BASE_URL}/floware/v1/message-processors/'
+        f'{message_processor_id}/execute'
+    )
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.post(
+                url, json={'input_data': processor_input}, timeout=60.0
+            )
+        except httpx.RequestError as e:
+            raise Exception(
+                f'Failed to reach message processor API for '
+                f'{message_processor_id}: {e}'
+            )
 
-    response_body_bytes = response.body
-    response_body = json.loads(response_body_bytes.decode('utf-8'))
+    try:
+        response_body = response.json()
+    except json.JSONDecodeError:
+        raise Exception(
+            f'Message processor {message_processor_id} returned non-JSON '
+            f'({response.status_code}): {response.text}'
+        )
 
-    # Check if there's an error in the response
     meta = response_body.get('meta', {})
-    if meta.get('status') == 'failure':
-        error_msg = meta.get('error', 'Unknown error')
+    if response.status_code != 200 or meta.get('status') == 'failure':
+        error_msg = meta.get('error', response.text)
         raise Exception(f'Message processor execution failed: {error_msg}')
 
     data = response_body.get('data')

--- a/wavefront/server/packages/flo_cloud/flo_cloud/postgres/postgres.py
+++ b/wavefront/server/packages/flo_cloud/flo_cloud/postgres/postgres.py
@@ -337,9 +337,14 @@ class PostgresClient:
             logger.error(f'Postgres connection test failed: {e}')
             return False
 
-    def insert_rows_json(self, table_name: str, data: List[Dict[str, Any]]) -> None:
-        if not data:
-            return
+    def _build_insert(
+        self, table_name: str, data: List[Dict[str, Any]]
+    ) -> Tuple[Any, List[Dict[str, Any]]]:
+        """Build the parameterized INSERT and the serialized rows for ``data``.
+
+        dict/list column values are wrapped in ``psycopg2.extras.Json``. Assumes
+        ``data`` is non-empty (callers guard for that).
+        """
         serialized = [
             {
                 k: psycopg2.extras.Json(v) if isinstance(v, (dict, list)) else v
@@ -353,6 +358,12 @@ class PostgresClient:
             cols=sql.SQL(', ').join(map(sql.Identifier, columns)),
             vals=sql.SQL(', ').join(sql.Placeholder(name=col) for col in columns),
         )
+        return query, serialized
+
+    def insert_rows_json(self, table_name: str, data: List[Dict[str, Any]]) -> None:
+        if not data:
+            return
+        query, serialized = self._build_insert(table_name, data)
         with self.get_connection() as conn:
             cursor = conn.cursor()
             try:
@@ -361,6 +372,33 @@ class PostgresClient:
             except psycopg2.Error as e:
                 conn.rollback()
                 logger.error(f'Insert error: {e}')
+                raise
+            finally:
+                cursor.close()
+
+    def insert_rows_json_multi(self, inserts: List[Dict[str, Any]]) -> None:
+        """Insert into multiple tables atomically, in a single transaction.
+
+        ``inserts`` is a list of ``{"table_name": str, "data": List[Dict]}``. All
+        tables are written on one connection and committed once; any failure rolls
+        back every table (all-or-nothing). Entries with empty ``data`` are skipped.
+        """
+        prepared = [
+            self._build_insert(spec['table_name'], spec['data'])
+            for spec in inserts
+            if spec.get('data')
+        ]
+        if not prepared:
+            return
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            try:
+                for query, serialized in prepared:
+                    cursor.executemany(query, serialized)
+                conn.commit()
+            except psycopg2.Error as e:
+                conn.rollback()
+                logger.error(f'Multi-insert error: {e}')
                 raise
             finally:
                 cursor.close()

--- a/wavefront/server/plugins/datasource/datasource/__init__.py
+++ b/wavefront/server/plugins/datasource/datasource/__init__.py
@@ -103,6 +103,9 @@ class DatasourcePlugin:
     def insert_rows_json(self, table_name: str, data: List[Dict[str, Any]]):
         return self.datasource.insert_rows_json(table_name, data)
 
+    def insert_rows_json_multi(self, inserts: List[Dict[str, Any]]):
+        return self.datasource.insert_rows_json_multi(inserts)
+
     async def execute_query(
         self, query: str, use_legacy_sql: bool = False, dry_run: bool = False, **kwargs
     ) -> Any:

--- a/wavefront/server/plugins/datasource/datasource/postgres/__init__.py
+++ b/wavefront/server/plugins/datasource/datasource/postgres/__init__.py
@@ -62,6 +62,9 @@ class PostgresPlugin(DataSourceABC):
     def insert_rows_json(self, table_name: str, data: List[Dict[str, Any]]) -> None:
         self.client.insert_rows_json(table_name, data)
 
+    def insert_rows_json_multi(self, inserts: List[Dict[str, Any]]) -> None:
+        self.client.insert_rows_json_multi(inserts)
+
     async def execute_query(
         self, query: str, use_legacy_sql: bool = False, dry_run: bool = False, **kwargs
     ) -> Any:

--- a/wavefront/server/plugins/datasource/datasource/types.py
+++ b/wavefront/server/plugins/datasource/datasource/types.py
@@ -82,6 +82,18 @@ class DataSourceABC(ABC):
     def insert_rows_json(self, table_name: str, data: List[Dict[str, Any]]) -> None:
         pass
 
+    def insert_rows_json_multi(self, inserts: List[Dict[str, Any]]) -> None:
+        """Insert into multiple tables atomically, in a single transaction.
+
+        ``inserts``: list of ``{"table_name": str, "data": List[Dict]}``. Concrete
+        (not abstract) with a NotImplementedError default, so datasource types that
+        don't support transactional multi-table insert stay instantiable; plugins
+        that do (e.g. Postgres) override this.
+        """
+        raise NotImplementedError(
+            f'{type(self).__name__} does not support transactional multi-table insert'
+        )
+
     @abstractmethod
     async def execute_dynamic_query(
         self,


### PR DESCRIPTION
add transactional multi-table insert for postgres datasources

Adds datasource_insert_multi: write rows into several tables of one Postgres datasource in a single all-or-nothing transaction. Spans the full stack:

- postgres client: extract _build_insert helper shared by single/multi inserts; add insert_rows_json_multi which writes all tables on one connection and commits once, rolling back every table on any failure (skips entries with empty data).
- plugin layer: PostgresPlugin.insert_rows_json_multi delegates to the client; DataSourceABC gains a concrete insert_rows_json_multi default that raises NotImplementedError (so non-Postgres types stay instantiable); DatasourcePlugin facade delegates through to the underlying datasource.
- api: POST /v1/datasources/{id}/resources stamps created_at per row and dispatches to the plugin, returning 501 for datasource types that don't support transactional multi-insert. Add TableInsert / InsertRowsJsonMultiPayload request models.
- tool: datasource_insert_multi tool calls the endpoint over HTTP; register it in DATASOURCE_REGISTRY and available_tools.json so flo_ai FunctionNodes can invoke it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added transactional multi-table row insertion for a single datasource (all-or-nothing), currently supported for Postgres.
  * Introduced a new API endpoint to submit per-table insert instructions in one request, returning inserted-row totals plus table count.
  * Inserted rows are now automatically annotated with a `created_at` timestamp.
  * Added a new tool (`datasource_insert_multi`) for atomic multi-table inserts.
* **Bug Fixes**
  * Improved handling for missing datasource configuration (404) and unsupported multi-table inserts (501).
  * Improved message processor execution via REST, including clearer network errors and safer JSON response parsing/handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->