### PR TITLE
fix: Add MSSQL ODBC driver dependencies to floware Dockerfile

### DIFF
--- a/wavefront/server/docker/floware.Dockerfile
+++ b/wavefront/server/docker/floware.Dockerfile
@@ -9,7 +9,18 @@ RUN apt-get update && apt-get install -y \
     gcc \
     libgl1 \
     libglib2.0-0 \
+    unixodbc \
+    unixodbc-dev \
+    curl \
+    gnupg \
     && rm -rf /var/lib/apt/lists/*
+
+# Add Microsoft's ODBC driver repository and install msodbcsql
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
+    curl https://packages.microsoft.com/config/ubuntu/22.04/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
+    apt-get update && \
+    ACCEPT_EULA=Y apt-get install -y msodbcsql18 && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY wavefront/server/pyproject.toml wavefront/server/uv.lock ./
 

--- a/wavefront/server/docker/floware.Dockerfile
+++ b/wavefront/server/docker/floware.Dockerfile
@@ -12,12 +12,13 @@ RUN apt-get update && apt-get install -y \
     unixodbc \
     unixodbc-dev \
     curl \
-    gnupg \
+    gnupg2 \
+    apt-transport-https \
     && rm -rf /var/lib/apt/lists/*
 
 # Add Microsoft's ODBC driver repository and install msodbcsql
-RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
-    curl https://packages.microsoft.com/config/ubuntu/22.04/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /usr/share/keyrings/microsoft-archive-keyring.gpg && \
+    curl https://packages.microsoft.com/config/ubuntu/22.04/prod.list | sed "s/^/deb [arch=amd64,arm64,armhf signed-by=\/usr\/share\/keyrings\/microsoft-archive-keyring.gpg] /" > /etc/apt/sources.list.d/microsoft-ubuntu-jammy-prod.list && \
     apt-get update && \
     ACCEPT_EULA=Y apt-get install -y msodbcsql18 && \
     rm -rf /var/lib/apt/lists/*

--- a/wavefront/server/docker/floware.Dockerfile
+++ b/wavefront/server/docker/floware.Dockerfile
@@ -17,8 +17,8 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Add Microsoft's ODBC driver repository and install msodbcsql
-RUN curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /usr/share/keyrings/microsoft-archive-keyring.gpg && \
-    curl https://packages.microsoft.com/config/ubuntu/22.04/prod.list | sed "s/^/deb [arch=amd64,arm64,armhf signed-by=\/usr\/share\/keyrings\/microsoft-archive-keyring.gpg] /" > /etc/apt/sources.list.d/microsoft-ubuntu-jammy-prod.list && \
+RUN curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /usr/share/keyrings/microsoft-archive-keyring.gpg && \
+    echo "deb [arch=amd64,arm64,armhf signed-by=/usr/share/keyrings/microsoft-archive-keyring.gpg] https://packages.microsoft.com/ubuntu/22.04/prod jammy main" > /etc/apt/sources.list.d/microsoft-ubuntu-jammy-prod.list && \
     apt-get update && \
     ACCEPT_EULA=Y apt-get install -y msodbcsql18 && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Fixes the MSSQL connection error "Failed to load the driver" by installing required system dependencies:
- unixodbc and unixodbc-dev (ODBC libraries)
- msodbcsql18 (Microsoft SQL Server ODBC driver)

These dependencies are required by the mssql-python package to establish connections to SQL Server databases.

Resolves: Driver Error: Connection operation failed; DDBC Error: Failed to load the driver

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the container build to install Microsoft ODBC Driver 18 support (including ODBC utilities and development headers).
  * Added required download/signing and transport tooling for fetching Microsoft packages.
  * Configured Microsoft’s apt repository for Ubuntu 22.04 and streamlined package installation and cleanup to reduce image bloat.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->