### PR TITLE
make functionnodes receive vars, msgs carry their producing node stamp

### DIFF
--- a/flo_ai/flo_ai/arium/arium.py
+++ b/flo_ai/flo_ai/arium/arium.py
@@ -220,8 +220,15 @@ class Arium(BaseArium):
         variables: Optional[Dict[str, Any]] = None,
     ):
         variables = variables if variables is not None else {}
+        # retag=False: these messages are received, not produced here. A parent
+        # passes its nodes' outputs straight into a sub-workflow, so the same
+        # BaseMessage objects land in this memory as 'input' — retagging them
+        # would erase the producer the parent recorded, and any input_filter
+        # reading provenance downstream would see 'input' for everything.
         [
-            self.memory.add(MessageMemoryItem(node='input', occurrence=0, result=msg))
+            self.memory.add(
+                MessageMemoryItem(node='input', occurrence=0, result=msg, retag=False)
+            )
             for msg in inputs
         ]
 
@@ -624,7 +631,10 @@ class Arium(BaseArium):
             if isinstance(node, Agent):
                 return await node.run(inputs, variables={})
             if isinstance(node, FunctionNode):
-                return await node.run(inputs, variables=None)
+                # Agents get {} because their prompts were already resolved against
+                # the variables in _resolve_agent_prompts. Function nodes have no
+                # such earlier pass, so they need the real mapping here.
+                return await node.run(inputs, variables=variables)
             if isinstance(node, ForEachNode):
                 foreach_results: List[MessageMemoryItem | BaseMessage] = await node.run(
                     inputs,

--- a/flo_ai/flo_ai/arium/arium.py
+++ b/flo_ai/flo_ai/arium/arium.py
@@ -38,6 +38,7 @@ class Arium(BaseArium):
         variables: Optional[Dict[str, Any]] = None,
         event_callback: Optional[Callable[[AriumEvent], None]] = None,
         events_filter: Optional[List[AriumEventType]] = None,
+        forwarded_from_parent: bool = False,
     ):
         """
         Execute the Arium workflow with optional event monitoring.
@@ -47,6 +48,10 @@ class Arium(BaseArium):
             variables: Variable substitutions for templated prompts
             event_callback: Function to call for each event (if None, no events are emitted)
             events_filter: List of event types to listen for (defaults to all)
+            forwarded_from_parent: Set by AriumNode, not by callers. Marks these
+                inputs as a parent workflow's node outputs being handed down, so
+                their recorded producer is kept instead of being reset to
+                'input'. A top-level caller's messages are always retagged.
 
         Returns:
             List of workflow execution results
@@ -98,7 +103,11 @@ class Arium(BaseArium):
 
                     # Execute the workflow with event support
                     result = await self._execute_graph(
-                        resolved_inputs, event_callback, events_filter, variables
+                        resolved_inputs,
+                        event_callback,
+                        events_filter,
+                        variables,
+                        forwarded_from_parent,
                     )
 
                     # Record successful workflow execution
@@ -156,7 +165,11 @@ class Arium(BaseArium):
 
                 # Execute the workflow with event support
                 result = await self._execute_graph(
-                    resolved_inputs, event_callback, events_filter, variables
+                    resolved_inputs,
+                    event_callback,
+                    events_filter,
+                    variables,
+                    forwarded_from_parent,
                 )
 
                 # Emit workflow completed event
@@ -204,12 +217,13 @@ class Arium(BaseArium):
         event_callback: Optional[Callable[[AriumEvent], None]] = None,
         events_filter: Optional[List[AriumEventType]] = None,
         variables: Optional[Dict[str, Any]] = None,
+        forwarded_from_parent: bool = False,
     ):
         async with aprofile(
             f'arium.execute_graph[{getattr(self, "name", "unnamed_workflow")}]'
         ):
             return await self._execute_graph_impl(
-                inputs, event_callback, events_filter, variables
+                inputs, event_callback, events_filter, variables, forwarded_from_parent
             )
 
     async def _execute_graph_impl(
@@ -218,16 +232,28 @@ class Arium(BaseArium):
         event_callback: Optional[Callable[[AriumEvent], None]] = None,
         events_filter: Optional[List[AriumEventType]] = None,
         variables: Optional[Dict[str, Any]] = None,
+        forwarded_from_parent: bool = False,
     ):
         variables = variables if variables is not None else {}
-        # retag=False: these messages are received, not produced here. A parent
-        # passes its nodes' outputs straight into a sub-workflow, so the same
-        # BaseMessage objects land in this memory as 'input' — retagging them
-        # would erase the producer the parent recorded, and any input_filter
-        # reading provenance downstream would see 'input' for everything.
+        # A parent hands its nodes' outputs straight to a sub-workflow, so the
+        # same BaseMessage objects land in this memory as 'input'. Retagging them
+        # there would erase the producer the parent recorded, and an input_filter
+        # reading provenance downstream would see 'input' for everything — hence
+        # retag=False on that path only.
+        #
+        # Top-level inputs are always retagged. A caller can legitimately pass a
+        # message that already carries a tag — feeding one workflow's results
+        # into another, or reusing a message object — and that tag names a node
+        # in a workflow that is not this one. Keeping it would let an unrelated
+        # (or caller-chosen) name drive this workflow's routing and filtering.
         [
             self.memory.add(
-                MessageMemoryItem(node='input', occurrence=0, result=msg, retag=False)
+                MessageMemoryItem(
+                    node='input',
+                    occurrence=0,
+                    result=msg,
+                    retag=not forwarded_from_parent,
+                )
             )
             for msg in inputs
         ]

--- a/flo_ai/flo_ai/arium/memory.py
+++ b/flo_ai/flo_ai/arium/memory.py
@@ -1,3 +1,4 @@
+import copy
 from abc import ABC, abstractmethod
 from typing import TypeVar, Generic, List, Dict, Optional, Any
 from dataclasses import dataclass, field
@@ -38,27 +39,45 @@ class MessageMemoryItem:
         """
         self.node: str = node
         self.occurrence: int = occurrence
-        self.result: BaseMessage = result
+        self.result: BaseMessage = self._tag(result, node, retag)
 
-        # Also record the producing node on the message itself, so provenance
-        # survives being unwrapped from this container. Arium hands nodes
-        # `[item.result for item in memory_items]`, and _flatten_results strips
-        # this wrapper whenever a sub-workflow or ForEach returns — a tag held
-        # only here would be lost in both cases. Downstream readers (e.g. the
-        # wavefront function-node adapter) use it to tell apart the outputs of
-        # several nodes selected by one input_filter.
-        #
-        # A message object is shared across memories: passing a node's result
-        # into a sub-workflow puts the SAME BaseMessage into that sub-workflow's
-        # memory. Overwriting the tag there would erase the producer the parent
-        # recorded, so `retag=False` marks the case where this item is merely
-        # receiving a message someone else produced. Storing a node's own output
-        # does retag, which is what lets a sub-workflow result take the parent's
-        # node name as it bubbles up.
-        if hasattr(result, 'metadata'):
-            metadata = result.metadata or {}
-            if retag or 'node' not in metadata:
-                result.metadata = {**metadata, 'node': node}
+    @staticmethod
+    def _tag(result: BaseMessage, node: str, retag: bool) -> BaseMessage:
+        """Record the producing node on the message, returning what to store.
+
+        The tag goes on the message itself, not just on this container, so that
+        provenance survives being unwrapped from it. Arium hands nodes
+        `[item.result for item in memory_items]`, and _flatten_results strips this
+        wrapper whenever a sub-workflow or ForEach returns — a tag held only here
+        would be lost in both cases. Downstream readers (e.g. the wavefront
+        function-node adapter) use it to tell apart the outputs of several nodes
+        selected by one input_filter.
+
+        A message object is shared: passing a node's result into a sub-workflow
+        puts the SAME BaseMessage into that sub-workflow's memory, and `run`
+        hands its results back to the caller, who may feed them into another
+        workflow. So reassigning a producer is done on a copy — the original
+        keeps the tag whoever else holds it is relying on, and only this memory
+        sees the new one. `retag=False` declines the reassignment altogether,
+        marking an item that is merely receiving a message someone else made.
+        """
+        if not hasattr(result, 'metadata'):
+            return result
+
+        metadata = result.metadata or {}
+        existing = metadata.get('node')
+
+        if existing is None:
+            # No producer to displace, so stamping in place loses nothing.
+            result.metadata = {**metadata, 'node': node}
+            return result
+
+        if not retag or existing == node:
+            return result
+
+        tagged = copy.copy(result)
+        tagged.metadata = {**metadata, 'node': node}
+        return tagged
 
     def to_dict(self) -> Dict[str, Any]:
         return {

--- a/flo_ai/flo_ai/arium/memory.py
+++ b/flo_ai/flo_ai/arium/memory.py
@@ -20,10 +20,45 @@ class StepStatus(Enum):
 
 
 class MessageMemoryItem:
-    def __init__(self, node: str, result: BaseMessage, occurrence: int = 0):
+    def __init__(
+        self,
+        node: str,
+        result: BaseMessage,
+        occurrence: int = 0,
+        retag: bool = True,
+    ):
+        """
+        Args:
+            node: Name of the node this result belongs to.
+            result: The message itself.
+            occurrence: Set by MessageMemory.add; how many times `node` has run.
+            retag: Whether to overwrite an existing provenance tag on `result`.
+                Pass False when the message is being *received* rather than
+                produced — see below.
+        """
         self.node: str = node
         self.occurrence: int = occurrence
         self.result: BaseMessage = result
+
+        # Also record the producing node on the message itself, so provenance
+        # survives being unwrapped from this container. Arium hands nodes
+        # `[item.result for item in memory_items]`, and _flatten_results strips
+        # this wrapper whenever a sub-workflow or ForEach returns — a tag held
+        # only here would be lost in both cases. Downstream readers (e.g. the
+        # wavefront function-node adapter) use it to tell apart the outputs of
+        # several nodes selected by one input_filter.
+        #
+        # A message object is shared across memories: passing a node's result
+        # into a sub-workflow puts the SAME BaseMessage into that sub-workflow's
+        # memory. Overwriting the tag there would erase the producer the parent
+        # recorded, so `retag=False` marks the case where this item is merely
+        # receiving a message someone else produced. Storing a node's own output
+        # does retag, which is what lets a sub-workflow result take the parent's
+        # node name as it bubbles up.
+        if hasattr(result, 'metadata'):
+            metadata = result.metadata or {}
+            if retag or 'node' not in metadata:
+                result.metadata = {**metadata, 'node': node}
 
     def to_dict(self) -> Dict[str, Any]:
         return {

--- a/flo_ai/flo_ai/arium/nodes.py
+++ b/flo_ai/flo_ai/arium/nodes.py
@@ -45,9 +45,12 @@ class AriumNode:
         )
 
         # Execute the nested Arium with isolated memory
+        # These inputs are this parent's node outputs, so the sub-workflow keeps
+        # the producer already recorded on them rather than resetting it.
         result = await self.arium.run(
             inputs=inputs,
             variables=execution_variables,
+            forwarded_from_parent=True,
         )
         return result
 

--- a/flo_ai/tests/unit-tests/test_arium_node_provenance.py
+++ b/flo_ai/tests/unit-tests/test_arium_node_provenance.py
@@ -35,14 +35,33 @@ class TestMessageProvenanceTag:
         """A nested result re-stored by a parent takes the parent's node name.
 
         The tag must describe the memory doing the filtering, so that
-        `input_filter` values and tags always agree.
+        `input_filter` values and tags always agree. The parent reads it off its
+        own item, which is the only view that has to be right.
         """
         message = UserMessage(content='{}')
 
-        MessageMemoryItem(node='inner_node', result=message)
-        MessageMemoryItem(node='outer_node', result=message)
+        inner = MessageMemoryItem(node='inner_node', result=message)
+        outer = MessageMemoryItem(node='outer_node', result=message)
 
-        assert message.metadata['node'] == 'outer_node'
+        assert outer.result.metadata['node'] == 'outer_node'
+        # The inner memory still describes what it actually produced.
+        assert inner.result.metadata['node'] == 'inner_node'
+
+    def test_reassigning_a_producer_does_not_mutate_the_shared_message(self):
+        """`run` hands its results back to the caller, who may pass them into
+        another workflow. Retagging in place there would rewrite the tags inside
+        the results the caller is still holding, so the new tag goes on a copy.
+        """
+        message = UserMessage(content='{}', metadata={'source': 'upload'})
+        MessageMemoryItem(node='node_a', result=message)
+
+        item = MessageMemoryItem(node='node_b', result=message)
+
+        assert item.result is not message
+        assert message.metadata['node'] == 'node_a'
+        assert item.result.metadata == {'source': 'upload', 'node': 'node_b'}
+        # The copy is shallow: the payload is shared, only the tag differs.
+        assert item.result.content is message.content
 
     def test_tolerates_result_without_metadata(self):
         """`.result` is occasionally a plain str, which has no metadata."""
@@ -114,6 +133,21 @@ class TestMessageProvenanceTag:
         assert [i.result.metadata['node'] for i in parent.memory.get()] == [
             'classifier'
         ]
+
+    def test_a_top_level_input_is_retagged(self):
+        """Preserving provenance is only correct for a parent handing inputs
+        down. A caller can pass a message that already carries a tag — feeding
+        one workflow's results into another, or reusing a message object — and
+        that tag names a node in some other workflow. It must not survive into
+        this one, where it would drive filtering and routing.
+        """
+        message = UserMessage(content='{}', metadata={'node': 'other_workflow_node'})
+
+        item = MessageMemoryItem(node='input', result=message, retag=True)
+
+        assert item.result.metadata['node'] == 'input'
+        # ...and the caller's copy is left as they gave it.
+        assert message.metadata['node'] == 'other_workflow_node'
 
 
 class TestFunctionNodeReceivesVariables:

--- a/flo_ai/tests/unit-tests/test_arium_node_provenance.py
+++ b/flo_ai/tests/unit-tests/test_arium_node_provenance.py
@@ -98,7 +98,7 @@ class TestMessageProvenanceTag:
         node reading provenance saw 'input' instead of the node that made it.
         """
         parent = Arium(memory=MessageMemory())
-        produced = UserMessage(content='{"doc_type": "broker_submission"}')
+        produced = UserMessage(content='{"label": "classified"}')
         parent.memory.add(MessageMemoryItem(node='classifier', result=produced))
 
         # What an AriumNode does: hand the parent's memory to a nested workflow.

--- a/flo_ai/tests/unit-tests/test_arium_node_provenance.py
+++ b/flo_ai/tests/unit-tests/test_arium_node_provenance.py
@@ -1,0 +1,152 @@
+"""Provenance tagging and variable propagation for Arium nodes.
+
+Covers two behaviours a downstream consumer depends on:
+
+1. Every message carries the name of the node that produced it, on the message
+   itself, so the tag survives being unwrapped out of ``MessageMemoryItem``.
+2. ``FunctionNode`` receives the workflow's variables, like every other node
+   type that can act on them.
+"""
+
+import pytest
+
+from flo_ai.arium.arium import Arium
+from flo_ai.arium.memory import MessageMemory, MessageMemoryItem
+from flo_ai.arium.nodes import FunctionNode
+from flo_ai.models import UserMessage
+
+
+class TestMessageProvenanceTag:
+    def test_tags_message_with_producing_node(self):
+        message = UserMessage(content='{"a": 1}')
+
+        MessageMemoryItem(node='node_a', result=message)
+
+        assert message.metadata['node'] == 'node_a'
+
+    def test_preserves_existing_metadata(self):
+        message = UserMessage(content='hi', metadata={'source': 'upload'})
+
+        MessageMemoryItem(node='node_a', result=message)
+
+        assert message.metadata == {'source': 'upload', 'node': 'node_a'}
+
+    def test_retag_on_bubble_up_wins(self):
+        """A nested result re-stored by a parent takes the parent's node name.
+
+        The tag must describe the memory doing the filtering, so that
+        `input_filter` values and tags always agree.
+        """
+        message = UserMessage(content='{}')
+
+        MessageMemoryItem(node='inner_node', result=message)
+        MessageMemoryItem(node='outer_node', result=message)
+
+        assert message.metadata['node'] == 'outer_node'
+
+    def test_tolerates_result_without_metadata(self):
+        """`.result` is occasionally a plain str, which has no metadata."""
+        item = MessageMemoryItem(node='node_a', result='not a message')
+
+        assert item.result == 'not a message'
+
+    def test_tag_survives_memory_roundtrip(self):
+        """The tag has to outlive `[item.result for item in memory.get()]`."""
+        memory = MessageMemory()
+        memory.add(
+            MessageMemoryItem(node='node_a', result=UserMessage(content='{"x":1}'))
+        )
+        memory.add(
+            MessageMemoryItem(node='node_b', result=UserMessage(content='{"y":2}'))
+        )
+
+        inputs = [item.result for item in memory.get(['node_a', 'node_b'])]
+
+        assert [m.metadata['node'] for m in inputs] == ['node_a', 'node_b']
+
+    def test_repeated_node_keeps_its_own_tag_per_message(self):
+        """A ForEach forwards N results all tagged with the same node name."""
+        messages = [UserMessage(content='{}') for _ in range(3)]
+        for message in messages:
+            MessageMemoryItem(node='iterator', result=message)
+
+        assert all(m.metadata['node'] == 'iterator' for m in messages)
+
+    def test_receiving_a_message_does_not_overwrite_its_producer(self):
+        """retag=False marks a message that is received rather than produced."""
+        message = UserMessage(content='{}')
+
+        MessageMemoryItem(node='node_a', result=message)
+        MessageMemoryItem(node='input', result=message, retag=False)
+
+        assert message.metadata['node'] == 'node_a'
+
+    def test_an_untagged_message_is_tagged_even_when_receiving(self):
+        """A real workflow input has no prior producer, so it becomes 'input'."""
+        message = UserMessage(content='{}')
+
+        MessageMemoryItem(node='input', result=message, retag=False)
+
+        assert message.metadata['node'] == 'input'
+
+    async def test_passing_a_result_into_a_subworkflow_preserves_its_tag(self):
+        """The failure this guards against.
+
+        A node's output is passed straight into a nested workflow, which seeds it
+        into its own memory as 'input'. Because both memories hold the SAME
+        BaseMessage, retagging there used to erase the producer — so a downstream
+        node reading provenance saw 'input' instead of the node that made it.
+        """
+        parent = Arium(memory=MessageMemory())
+        produced = UserMessage(content='{"doc_type": "broker_submission"}')
+        parent.memory.add(MessageMemoryItem(node='classifier', result=produced))
+
+        # What an AriumNode does: hand the parent's memory to a nested workflow.
+        nested = Arium(memory=MessageMemory())
+        inputs = [item.result for item in parent.memory.get()]
+        for message in inputs:
+            nested.memory.add(
+                MessageMemoryItem(node='input', result=message, retag=False)
+            )
+
+        assert produced.metadata['node'] == 'classifier'
+        # And the parent's own view is unchanged.
+        assert [i.result.metadata['node'] for i in parent.memory.get()] == [
+            'classifier'
+        ]
+
+
+class TestFunctionNodeReceivesVariables:
+    async def test_variables_reach_the_function(self):
+        seen = {}
+
+        async def capture(inputs=None, variables=None, **kwargs):
+            seen['variables'] = variables
+            return 'done'
+
+        node = FunctionNode(name='capture', function=capture)
+        arium = Arium(memory=MessageMemory())
+
+        await arium._dispatch_node_run(
+            node, 'function', [UserMessage(content='{}')], {'tone': 'formal'}
+        )
+
+        assert seen['variables'] == {'tone': 'formal'}
+
+    async def test_empty_variables_are_passed_through(self):
+        seen = {}
+
+        async def capture(inputs=None, variables=None, **kwargs):
+            seen['variables'] = variables
+            return 'done'
+
+        node = FunctionNode(name='capture', function=capture)
+        arium = Arium(memory=MessageMemory())
+
+        await arium._dispatch_node_run(node, 'function', [], {})
+
+        assert seen['variables'] == {}
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])

--- a/wavefront/server/modules/agents_module/agents_module/controllers/workflow_controller.py
+++ b/wavefront/server/modules/agents_module/agents_module/controllers/workflow_controller.py
@@ -16,6 +16,7 @@ from common_module.common_container import CommonContainer
 from agents_module.agents_container import AgentsContainer
 from agents_module.services.workflow_crud_service import WorkflowCrudService
 from agents_module.services.workflow_inference_service import WorkflowInferenceService
+from agents_module.utils.execution_variable_utils import with_execution_variables
 from agents_module.services.workflow_events import (
     event_streamer,
     create_workflow_event_callback,
@@ -92,8 +93,11 @@ async def workflow_inference(
     event_callback = None
     events_filter = None
 
+    # Minted for every run, not only streaming ones: it is passed into the
+    # workflow as a variable so nodes can stamp their outputs with the run id.
+    execution_id = str(uuid.uuid4())
+
     if listen_events or request_body.listen_events:
-        execution_id = str(uuid.uuid4())
         event_callback = create_workflow_event_callback(
             execution_id, namespace, workflow_id
         )
@@ -117,7 +121,9 @@ async def workflow_inference(
                     workflow_inference_service.perform_inference(
                         workflow_name=workflow_id,
                         namespace=namespace,
-                        variables=request_body.variables or {},
+                        variables=with_execution_variables(
+                            request_body.variables, execution_id
+                        ),
                         inputs=resolved_inputs
                         if isinstance(resolved_inputs, list)
                         else [resolved_inputs],
@@ -196,7 +202,7 @@ async def workflow_inference(
         result, execution_time = await workflow_inference_service.perform_inference(
             workflow_name=workflow_id,
             namespace=namespace,
-            variables=request_body.variables or {},
+            variables=with_execution_variables(request_body.variables, execution_id),
             inputs=resolved_inputs
             if isinstance(resolved_inputs, list)
             else [resolved_inputs],
@@ -300,8 +306,11 @@ async def workflow_inference_v2(
     event_callback = None
     events_filter = None
 
+    # Minted for every run, not only streaming ones: it is passed into the
+    # workflow as a variable so nodes can stamp their outputs with the run id.
+    execution_id = str(uuid.uuid4())
+
     if listen_events or request_body.listen_events:
-        execution_id = str(uuid.uuid4())
         event_callback = create_workflow_event_callback(
             execution_id, namespace, workflow_name
         )
@@ -324,7 +333,9 @@ async def workflow_inference_v2(
                 inference_task = asyncio.create_task(
                     workflow_inference_service.perform_inference_v2(
                         workflow_data=workflow_data,
-                        variables=request_body.variables or {},
+                        variables=with_execution_variables(
+                            request_body.variables, execution_id
+                        ),
                         inputs=resolved_inputs
                         if isinstance(resolved_inputs, list)
                         else [resolved_inputs],
@@ -401,7 +412,7 @@ async def workflow_inference_v2(
         # Non-streaming mode - normal JSON response
         result, execution_time = await workflow_inference_service.perform_inference_v2(
             workflow_data=workflow_data,
-            variables=request_body.variables or {},
+            variables=with_execution_variables(request_body.variables, execution_id),
             inputs=resolved_inputs
             if isinstance(resolved_inputs, list)
             else [resolved_inputs],

--- a/wavefront/server/modules/agents_module/agents_module/services/async_agentic_execution_service.py
+++ b/wavefront/server/modules/agents_module/agents_module/services/async_agentic_execution_service.py
@@ -18,6 +18,7 @@ from agents_module.models.async_agentic_execution_schemas import (
     AgenticExecutionStatusResponse,
 )
 from agents_module.utils.celery_client import get_celery_client
+from agents_module.utils.execution_variable_utils import with_execution_variables
 
 _MIME_TO_EXT = {
     'application/pdf': '.pdf',
@@ -197,7 +198,7 @@ class AsyncAgenticExecutionService:
             'execution_id': str(execution_id),
             'entity_id': str(agent_id),
             'entity_type': 'agent',
-            'variables': variables or {},
+            'variables': with_execution_variables(variables, execution_id),
             'inputs': clean_inputs,
             'llm_config': llm_config,
             'output_json_enabled': output_json_enabled,
@@ -268,7 +269,7 @@ class AsyncAgenticExecutionService:
             'entity_type': 'workflow',
             'workflow_name': workflow_name,
             'namespace': namespace,
-            'variables': variables or {},
+            'variables': with_execution_variables(variables, execution_id),
             'inputs': clean_inputs,
             'llm_config': None,
             'output_json_enabled': output_json_enabled,

--- a/wavefront/server/modules/agents_module/agents_module/utils/execution_variable_utils.py
+++ b/wavefront/server/modules/agents_module/agents_module/utils/execution_variable_utils.py
@@ -1,0 +1,37 @@
+"""Workflow variables contributed by the platform itself.
+
+Callers pass their own domain variables through `variables` untouched; this
+module adds the one value wavefront owns — the id of the run — so a node inside
+a workflow can stamp its outputs with the execution that produced them.
+
+`variables` is the only channel that reaches a node: the inference service is
+never handed the execution id, and threading a new parameter through
+`perform_inference` -> `arium.run` -> the node protocol would be far more
+invasive for the same result.
+
+Kept deliberately small and use-case agnostic. Wavefront is middleware for any
+use case, so it must not know about, mint or default a caller's domain keys — it
+contributes only its own identifier here.
+"""
+
+from typing import Any, Dict, Optional
+from uuid import UUID
+
+#: Variable name carrying this run's execution id.
+#:
+#: Prefixed because the injection applies to *every* workflow on the server and
+#: `variables` is user-facing — agent prompts resolve `{var}` from it — so a bare
+#: `execution_id` could collide with a caller's own variable of that name and
+#: silently change an existing workflow's behaviour.
+EXECUTION_ID_VARIABLE = '_wf_execution_id'
+
+
+def with_execution_variables(
+    variables: Optional[Dict[str, Any]],
+    execution_id: UUID | str,
+) -> Dict[str, Any]:
+    """Return ``variables`` plus this run's execution id.
+
+    The injected entry is applied last so a caller cannot override it.
+    """
+    return {**(variables or {}), EXECUTION_ID_VARIABLE: str(execution_id)}

--- a/wavefront/server/modules/common_module/common_module/utils/serializer.py
+++ b/wavefront/server/modules/common_module/common_module/utils/serializer.py
@@ -1,4 +1,5 @@
 from datetime import datetime, date
+from decimal import Decimal
 import uuid
 
 
@@ -9,6 +10,13 @@ def serialize_values(input):
             return str(input)
         elif isinstance(input, (datetime, date)):
             return input.isoformat()
+        # Postgres numeric/decimal arrives as Decimal, which json.dumps rejects.
+        # float keeps it a JSON number, so callers can do arithmetic on it
+        # without parsing — at the cost of float's ~15-17 significant digits.
+        # numeric is arbitrary-precision, so a wider value is rounded here;
+        # return str instead if exactness ever matters more than ergonomics.
+        elif isinstance(input, Decimal):
+            return float(input)
         elif isinstance(input, list):
             return [serialize_values(item) for item in input]
         elif hasattr(input, '_asdict'):
@@ -23,6 +31,8 @@ def serialize_values(input):
             result[column] = str(value)
         elif isinstance(value, (datetime, date)):
             result[column] = value.isoformat()
+        elif isinstance(value, Decimal):
+            result[column] = float(value)
         elif isinstance(value, dict):
             result[column] = serialize_values(value)
         elif isinstance(value, list):

--- a/wavefront/server/modules/tools_module/tools_module/registry/function_node_adapter.py
+++ b/wavefront/server/modules/tools_module/tools_module/registry/function_node_adapter.py
@@ -68,23 +68,33 @@ def extract_function_params(
         by_node: Dict[str, List[Any]] = {}
         ordered: List[Any] = []
 
-        for message in inputs:
-            if not (hasattr(message, 'content') and isinstance(message.content, str)):
+        last_index = len(inputs) - 1
+
+        # The last message is the one the node is contractually fed, so anything
+        # that stops it being read has to fail loudly — proceeding would call the
+        # function with only the earlier messages' params, i.e. on stale or empty
+        # data, and surface as a confusing error somewhere further in. Earlier
+        # messages may legitimately be unreadable now that a wider input_filter
+        # can select the raw workflow inputs (e.g. an uploaded document, whose
+        # content is a DocumentMessageContent rather than text), which were never
+        # looked at before; those are skipped.
+        for index, message in enumerate(inputs):
+            content = getattr(message, 'content', None)
+
+            if not isinstance(content, str):
+                if index == last_index:
+                    raise ValueError(
+                        f'Function node input must be a JSON object, but the last '
+                        f'input has content of type {type(content).__name__}.'
+                    )
                 continue
 
             try:
-                parsed = FloUtils.extract_jsons_from_string(
-                    message.content, strict=True
-                )
+                parsed = FloUtils.extract_jsons_from_string(content, strict=True)
             except (json.JSONDecodeError, TypeError, ValueError):
-                # The last message is the one the node is contractually fed, so
-                # it must still fail loudly. Earlier messages may legitimately be
-                # non-JSON now that a wider input_filter can select the raw
-                # workflow inputs (e.g. uploaded documents), which were never
-                # read before.
-                if message is inputs[-1]:
+                if index == last_index:
                     raise ValueError(
-                        f'Invalid JSON: {message.content}. Function node input must be a JSON object.'
+                        f'Invalid JSON: {content}. Function node input must be a JSON object.'
                     )
                 continue
 

--- a/wavefront/server/modules/tools_module/tools_module/registry/function_node_adapter.py
+++ b/wavefront/server/modules/tools_module/tools_module/registry/function_node_adapter.py
@@ -36,10 +36,26 @@ def extract_function_params(
     Parameters are extracted with this priority (higher priority overrides lower):
     1. kwargs (highest priority)
     2. variables dict
-    3. inputs (lowest priority - extracted from last message as JSON)
+    3. inputs (lowest priority - every message parsed as JSON, in order, last wins)
+
+    Every message in ``inputs`` is parsed, not just the last one: a node with
+    ``input_filter: [a, b]`` is handed both nodes' outputs, and reading only the
+    last would silently discard the rest. Two extra keys are added for nodes that
+    need to tell those outputs apart:
+
+    - ``node_outputs``: ``{producing_node_name: [parsed, ...]}``. List-valued
+      because a ForEach with ``forward_all_results`` emits N results all tagged
+      with the ForEach node's own name. Requires the ``metadata['node']`` tag
+      that ``MessageMemoryItem`` stamps onto each message.
+    - ``input_list``: the same parsed payloads in execution order.
+
+    The flat merge is kept so existing function nodes are unaffected — they read
+    their arguments straight out of the upstream node's JSON, and because the
+    merge iterates in order with last-wins, a single-input node produces exactly
+    the same params as before.
 
     Args:
-        inputs: List of BaseMessage objects, typically the last one contains function params
+        inputs: List of BaseMessage objects carrying function params as JSON
         variables: Dictionary of variables that may contain function parameters
         **kwargs: Additional keyword arguments (highest priority)
 
@@ -49,16 +65,39 @@ def extract_function_params(
     params = {}
 
     if inputs:
-        last_input = inputs[-1]
-        if hasattr(last_input, 'content') and isinstance(last_input.content, str):
+        by_node: Dict[str, List[Any]] = {}
+        ordered: List[Any] = []
+
+        for message in inputs:
+            if not (hasattr(message, 'content') and isinstance(message.content, str)):
+                continue
+
             try:
-                params.update(
-                    FloUtils.extract_jsons_from_string(last_input.content, strict=True)
+                parsed = FloUtils.extract_jsons_from_string(
+                    message.content, strict=True
                 )
             except (json.JSONDecodeError, TypeError, ValueError):
-                raise ValueError(
-                    f'Invalid JSON: {last_input.content}. Function node input must be a JSON object.'
-                )
+                # The last message is the one the node is contractually fed, so
+                # it must still fail loudly. Earlier messages may legitimately be
+                # non-JSON now that a wider input_filter can select the raw
+                # workflow inputs (e.g. uploaded documents), which were never
+                # read before.
+                if message is inputs[-1]:
+                    raise ValueError(
+                        f'Invalid JSON: {message.content}. Function node input must be a JSON object.'
+                    )
+                continue
+
+            ordered.append(parsed)
+            producing_node = (getattr(message, 'metadata', None) or {}).get('node')
+            if producing_node:
+                by_node.setdefault(producing_node, []).append(parsed)
+
+        for parsed in ordered:
+            params.update(parsed)
+
+        params['node_outputs'] = by_node
+        params['input_list'] = ordered
 
     if variables:
         params.update(variables)
@@ -72,8 +111,15 @@ def _build_call_kwargs(
     all_params: Dict[str, Any],
     kwargs: Dict[str, Any],
     excluded_params: set,
+    accepts_var_keyword: bool = False,
 ) -> Dict[str, Any]:
-    """Build keyword arguments for calling the original function."""
+    """Build keyword arguments for calling the original function.
+
+    Only parameters the signature names are forwarded, unless the function
+    declares ``**kwargs`` — those take arbitrary dynamic parameters (the message
+    processor and API service tools build their payload from whatever they are
+    given), so everything else collected is passed through to them as well.
+    """
     call_kwargs = {}
     for param_name in param_names:
         if param_name in excluded_params:
@@ -82,6 +128,13 @@ def _build_call_kwargs(
             call_kwargs[param_name] = kwargs[param_name]
         elif param_name in all_params:
             call_kwargs[param_name] = all_params[param_name]
+
+    if accepts_var_keyword:
+        for param_name, value in all_params.items():
+            if param_name in excluded_params:
+                continue
+            call_kwargs.setdefault(param_name, value)
+
     return call_kwargs
 
 
@@ -91,11 +144,18 @@ def _validate_required_params(
     function_name: str,
     excluded_params: set,
 ) -> None:
-    """Validate that all required parameters are present."""
+    """Validate that all required parameters are present.
+
+    Variadic parameters (``*args`` / ``**kwargs``) report no default, so they
+    would otherwise be reported as missing required arguments — they are not,
+    they simply collect whatever else is passed.
+    """
+    variadic = (inspect.Parameter.VAR_KEYWORD, inspect.Parameter.VAR_POSITIONAL)
     required_params = [
         param_name
         for param_name, param in sig.parameters.items()
         if param_name not in excluded_params
+        and param.kind not in variadic
         and param.default == inspect.Parameter.empty
     ]
 
@@ -147,6 +207,9 @@ def create_function_node_adapter(
     param_names = list(sig.parameters.keys())
     excluded_params = {'inputs', 'variables'}
     is_async = inspect.iscoroutinefunction(original_function)
+    accepts_var_keyword = any(
+        param.kind == inspect.Parameter.VAR_KEYWORD for param in sig.parameters.values()
+    )
 
     async def adapted_function(
         inputs: Optional[List[BaseMessage]] = None,
@@ -167,7 +230,11 @@ def create_function_node_adapter(
         try:
             all_params = extract_function_params(inputs, variables, **kwargs)
             call_kwargs = _build_call_kwargs(
-                param_names, all_params, kwargs, excluded_params
+                param_names,
+                all_params,
+                kwargs,
+                excluded_params,
+                accepts_var_keyword,
             )
             _validate_required_params(sig, call_kwargs, function_name, excluded_params)
 

--- a/wavefront/server/modules/tools_module/tools_module/registry/registries/util_function_registry.py
+++ b/wavefront/server/modules/tools_module/tools_module/registry/registries/util_function_registry.py
@@ -1,7 +1,9 @@
 from tools_module.utils.message_processor_fn import execute_message_processor_fn
 from tools_module.utils.api_service_fn import execute_api_service_fn
+from tools_module.utils.passthrough_fn import passthrough
 
 UTIL_FUNCTION_REGISTRY = {
     'message_processor': execute_message_processor_fn,
     'rf_api_service': execute_api_service_fn,
+    'passthrough': passthrough,
 }

--- a/wavefront/server/modules/tools_module/tools_module/utils/message_processor_fn.py
+++ b/wavefront/server/modules/tools_module/tools_module/utils/message_processor_fn.py
@@ -20,7 +20,7 @@ async def execute_message_processor_fn(message_processor_id: str, **kwargs) -> s
     # Everything except the processor id is the processor's input_data, and it
     # arrives in two shapes at once:
     #   - nested under 'kwargs' when an upstream agent's parser wrapped the
-    #     payload in a top-level `kwargs` object (see person_multi_insert_mp)
+    #     payload in a top-level `kwargs` object
     #   - flat, for workflow variables and the adapter's `node_outputs` key,
     #     which the adapter forwards because this function declares **kwargs
     # Both are merged so a processor can use either; nested wins on conflict,

--- a/wavefront/server/modules/tools_module/tools_module/utils/message_processor_fn.py
+++ b/wavefront/server/modules/tools_module/tools_module/utils/message_processor_fn.py
@@ -37,13 +37,16 @@ async def execute_message_processor_fn(message_processor_id: str, **kwargs) -> s
         for k, v in kwargs.items()
         if k not in ('message_processor_id', 'input_list')
     }
-    nested_input = input_data.get('kwargs') or {}
-    flat_input = {k: v for k, v in input_data.items() if k != 'kwargs'}
-    processor_input = (
-        {**flat_input, **nested_input}
-        if isinstance(nested_input, dict)
-        else nested_input
-    )
+    # Only a dict-valued 'kwargs' is the legacy wrapper. Any other value is just
+    # a parameter a processor happens to have named 'kwargs', so it stays where
+    # it is — unwrapping it would send that one value as the whole payload and
+    # drop the variables and node_outputs alongside it.
+    nested_input = input_data.get('kwargs')
+    if isinstance(nested_input, dict):
+        flat_input = {k: v for k, v in input_data.items() if k != 'kwargs'}
+        processor_input = {**flat_input, **nested_input}
+    else:
+        processor_input = input_data
 
     body = {'input_data': processor_input}
     payload_bytes = len(json.dumps(body, default=str))

--- a/wavefront/server/modules/tools_module/tools_module/utils/message_processor_fn.py
+++ b/wavefront/server/modules/tools_module/tools_module/utils/message_processor_fn.py
@@ -17,11 +17,36 @@ async def execute_message_processor_fn(message_processor_id: str, **kwargs) -> s
     Returns:
         Result from message processor execution as string
     """
-    # Everything except the processor id is the processor's input_data. The
-    # function-node adapter passes the actual inputs under a 'kwargs' key; fall
-    # back to the flat params if that key isn't present.
-    input_data = {k: v for k, v in kwargs.items() if k != 'message_processor_id'}
-    processor_input = input_data.get('kwargs', input_data)
+    # Everything except the processor id is the processor's input_data, and it
+    # arrives in two shapes at once:
+    #   - nested under 'kwargs' when an upstream agent's parser wrapped the
+    #     payload in a top-level `kwargs` object (see person_multi_insert_mp)
+    #   - flat, for workflow variables and the adapter's `node_outputs` key,
+    #     which the adapter forwards because this function declares **kwargs
+    # Both are merged so a processor can use either; nested wins on conflict,
+    # preserving the behaviour of processors written against the old shape.
+    #
+    # `input_list` is dropped: it holds the same payloads as `node_outputs`, just
+    # ungrouped, so forwarding both doubles the bytes the JS runtime has to
+    # receive and parse — enough to blow its script timeout on a large document
+    # set. A processor that needs ordering can read node_outputs, which is keyed
+    # by producing node. (The passthrough node still gets input_list: it names
+    # the parameter explicitly, so it is bound before this forwarding applies.)
+    input_data = {
+        k: v
+        for k, v in kwargs.items()
+        if k not in ('message_processor_id', 'input_list')
+    }
+    nested_input = input_data.get('kwargs') or {}
+    flat_input = {k: v for k, v in input_data.items() if k != 'kwargs'}
+    processor_input = (
+        {**flat_input, **nested_input}
+        if isinstance(nested_input, dict)
+        else nested_input
+    )
+
+    body = {'input_data': processor_input}
+    payload_bytes = len(json.dumps(body, default=str))
 
     url = (
         f'{FLOWARE_BASE_URL}/floware/v1/message-processors/'
@@ -49,14 +74,27 @@ async def execute_message_processor_fn(message_processor_id: str, **kwargs) -> s
     meta = response_body.get('meta', {})
     if response.status_code != 200 or meta.get('status') == 'failure':
         error_msg = meta.get('error', response.text)
-        raise Exception(f'Message processor execution failed: {error_msg}')
+        # Name the processor and the payload size. A workflow can run several
+        # processors, so "execution failed" on its own does not say which one —
+        # and the usual causes (script timeout, memory) are size-driven, so the
+        # byte count is the first thing worth knowing.
+        raise Exception(
+            f'Message processor {message_processor_id} execution failed '
+            f'({payload_bytes:,} bytes sent, keys: {sorted(processor_input)}): '
+            f'{error_msg}'
+        )
 
     data = response_body.get('data')
     if data is None:
-        raise Exception('Message processor response has no data field')
+        raise Exception(
+            f'Message processor {message_processor_id} response has no data field'
+        )
 
     result = data.get('result')
     if result is None:
-        raise Exception('Message processor response data has no result field')
+        raise Exception(
+            f'Message processor {message_processor_id} response data has no '
+            'result field'
+        )
 
     return result

--- a/wavefront/server/modules/tools_module/tools_module/utils/passthrough_fn.py
+++ b/wavefront/server/modules/tools_module/tools_module/utils/passthrough_fn.py
@@ -1,0 +1,39 @@
+"""Re-emit an earlier node's output as this node's output.
+
+A workflow returns the output of whichever node ran last, so any node that has to
+run at the end for its side effect — writing to a datasource, calling an external
+service — becomes the workflow's answer, replacing whatever the caller actually
+wanted. This node runs after it and puts the real result back:
+
+    - name: final_result
+      function_name: passthrough
+      input_filter: [quote_generator]   # whose output to re-emit
+
+Being a function node it makes no model call, so the value is never re-derived or
+re-typed on the way through.
+
+``input_list`` is supplied by the function-node adapter: every message the node's
+``input_filter`` selected, parsed, in execution order. Selecting exactly one node
+therefore makes this an identity function on that node's output. Selecting several
+re-emits the last of them.
+"""
+
+import json
+from typing import Any, List, Optional
+
+
+async def passthrough(input_list: Optional[List[Any]] = None) -> str:
+    """Return the last selected upstream payload, unchanged.
+
+    The payload has already been parsed from JSON by the adapter, so it is
+    re-serialised on the way out. That round-trip preserves content and types
+    exactly; only insignificant formatting (key order is kept, whitespace is not)
+    can differ from the upstream node's own rendering.
+    """
+    if not input_list:
+        return ''
+
+    payload = input_list[-1]
+    if isinstance(payload, str):
+        return payload
+    return json.dumps(payload)

--- a/wavefront/server/modules/tools_module/tools_module/utils/passthrough_fn.py
+++ b/wavefront/server/modules/tools_module/tools_module/utils/passthrough_fn.py
@@ -7,7 +7,7 @@ wanted. This node runs after it and puts the real result back:
 
     - name: final_result
       function_name: passthrough
-      input_filter: [quote_generator]   # whose output to re-emit
+      input_filter: [some_upstream_node]   # whose output to re-emit
 
 Being a function node it makes no model call, so the value is never re-derived or
 re-typed on the way through.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `passthrough` utility to return selected upstream results without an extra model call.
  * Workflow executions now always include an execution ID for consistent tracking.
  * Function nodes now receive the resolved workflow variables and richer input payloads.
* **Bug Fixes**
  * Preserved message provenance correctly across nested workflows.
  * Improved JSON/function input parsing to build parameters from all provided messages.
  * Enhanced serialization to support `Decimal` values via JSON-friendly encoding.
  * Strengthened message processor request building, validation, and error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->