### PR TITLE
update datasource single table, multi table atomic apis

### DIFF
--- a/wavefront/server/modules/plugins_module/plugins_module/controllers/datasource_controller.py
+++ b/wavefront/server/modules/plugins_module/plugins_module/controllers/datasource_controller.py
@@ -33,7 +33,10 @@ from plugins_module.utils.helper import (
     AddDatasourcePayload,
     UpdateDatasourcePayload,
     InsertRowsJsonPayload,
+    UpdateRowsJsonPayload,
+    UpdateRowsJsonMultiPayload,
 )
+from flo_cloud.postgres import NoRowsMatchedError
 from plugins_module.plugins_container import PluginsContainer
 from user_management_module.user_container import UserContainer
 from user_management_module.services.user_service import UserService
@@ -597,6 +600,181 @@ async def insert_rows_json(
         content=response_formatter.buildSuccessResponse(
             {
                 'message': f'Inserted {len(insert_rows_json_payload.data)} rows successfully'
+            }
+        ),
+    )
+
+
+# Registered BEFORE the single-table PATCH below: FastAPI matches in declaration
+# order, so the '{resource_id}' route would otherwise swallow this one with
+# resource_id='update'. (Same reason '/resources/insert' precedes its own
+# catch-all. It does mean a table literally named 'update' cannot be reached by
+# the single-table endpoint — as is already true for one named 'insert'.)
+@datasource_router.patch('/v1/datasources/{datasource_id}/resources/update')
+@inject
+async def update_rows_json_multi(
+    request: Request,
+    datasource_id: str,
+    update_rows_json_multi_payload: UpdateRowsJsonMultiPayload,
+    response_formatter: ResponseFormatter = Depends(
+        Provide[CommonContainer.response_formatter]
+    ),
+):
+    """Update rows across multiple tables of one datasource atomically.
+
+    All tables are written in a single transaction (all-or-nothing). By default a
+    filter that matches nothing aborts the whole update: the premise here is that
+    these rows move together, so a target that does not exist means the premise is
+    false. Pass `require_all_matched: false` for best-effort semantics.
+
+    Currently only Postgres supports this; other datasource types return 501.
+    """
+    if not update_rows_json_multi_payload.updates:
+        return JSONResponse(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            content=response_formatter.buildErrorResponse('No updates provided'),
+        )
+
+    for update in update_rows_json_multi_payload.updates:
+        if not update.filter.strip():
+            return JSONResponse(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                content=response_formatter.buildErrorResponse(
+                    'A non-empty filter is required to update rows, missing for '
+                    f'table {update.table_name}'
+                ),
+            )
+        if not update.data:
+            return JSONResponse(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                content=response_formatter.buildErrorResponse(
+                    f'No columns to update for table {update.table_name}'
+                ),
+            )
+
+    datasource_type, datasource_config = await get_datasource_config(datasource_id)
+    if not datasource_config:
+        return JSONResponse(
+            status_code=status.HTTP_404_NOT_FOUND,
+            content=response_formatter.buildErrorResponse(
+                f'Datasource not found: {datasource_id}'
+            ),
+        )
+
+    datasource_plugin = DatasourcePlugin(datasource_type, datasource_config)
+
+    try:
+        results = await asyncio.to_thread(
+            datasource_plugin.update_rows_json_multi,
+            [update.model_dump() for update in update_rows_json_multi_payload.updates],
+            update_rows_json_multi_payload.require_all_matched,
+        )
+    except NotImplementedError as e:
+        return JSONResponse(
+            status_code=status.HTTP_501_NOT_IMPLEMENTED,
+            content=response_formatter.buildErrorResponse(str(e)),
+        )
+    except NoRowsMatchedError as e:
+        # 409, not 404: the request was well formed and every statement was valid,
+        # but the database is not in the state the caller expected. Nothing was
+        # written — the transaction was rolled back before this was raised.
+        return JSONResponse(
+            status_code=status.HTTP_409_CONFLICT,
+            content=response_formatter.buildErrorResponse(str(e)),
+        )
+    except ValueError as e:
+        return JSONResponse(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            content=response_formatter.buildErrorResponse(str(e)),
+        )
+
+    total_rows = sum(result['updated_rows'] for result in results)
+    return JSONResponse(
+        status_code=status.HTTP_200_OK,
+        content=response_formatter.buildSuccessResponse(
+            {
+                'message': (
+                    f'Updated {total_rows} rows across '
+                    f'{len(results)} table(s) successfully'
+                ),
+                'updated_rows': total_rows,
+                'results': results,
+            }
+        ),
+    )
+
+
+@datasource_router.patch('/v1/datasources/{datasource_id}/resources/{resource_id}')
+@inject
+async def update_rows_json(
+    request: Request,
+    datasource_id: str,
+    resource_id: str,
+    update_rows_json_payload: UpdateRowsJsonPayload,
+    response_formatter: ResponseFormatter = Depends(
+        Provide[CommonContainer.response_formatter]
+    ),
+):
+    """Update the rows of one table matching an OData filter.
+
+    The filter travels in the body rather than as a `$filter` query param (the
+    shape the read endpoint uses, because a GET has no body): a mutation's
+    predicate should not end up in access logs or a Referer header, and putting
+    it in the body spares the caller from URL-encoding the quotes and spaces in
+    `id eq '...'`.
+
+    Currently only Postgres supports this; other datasource types return 501.
+    """
+    if not update_rows_json_payload.filter.strip():
+        return JSONResponse(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            content=response_formatter.buildErrorResponse(
+                'A non-empty filter is required to update rows'
+            ),
+        )
+
+    if not update_rows_json_payload.data:
+        return JSONResponse(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            content=response_formatter.buildErrorResponse('No columns to update'),
+        )
+
+    datasource_type, datasource_config = await get_datasource_config(datasource_id)
+    if not datasource_config:
+        return JSONResponse(
+            status_code=status.HTTP_404_NOT_FOUND,
+            content=response_formatter.buildErrorResponse(
+                f'Datasource not found: {datasource_id}'
+            ),
+        )
+
+    datasource_plugin = DatasourcePlugin(datasource_type, datasource_config)
+
+    try:
+        updated_rows = await asyncio.to_thread(
+            datasource_plugin.update_rows_json,
+            resource_id,
+            update_rows_json_payload.data,
+            update_rows_json_payload.filter,
+        )
+    except NotImplementedError as e:
+        return JSONResponse(
+            status_code=status.HTTP_501_NOT_IMPLEMENTED,
+            content=response_formatter.buildErrorResponse(str(e)),
+        )
+    except ValueError as e:
+        # Unparseable filter, or one that resolved to nothing.
+        return JSONResponse(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            content=response_formatter.buildErrorResponse(str(e)),
+        )
+
+    return JSONResponse(
+        status_code=status.HTTP_200_OK,
+        content=response_formatter.buildSuccessResponse(
+            {
+                'message': f'Updated {updated_rows} rows successfully',
+                'updated_rows': updated_rows,
             }
         ),
     )

--- a/wavefront/server/modules/plugins_module/plugins_module/utils/helper.py
+++ b/wavefront/server/modules/plugins_module/plugins_module/utils/helper.py
@@ -22,6 +22,33 @@ class InsertRowsJsonPayload(BaseModel):
     data: List[Dict[str, Any]]
 
 
+class UpdateRowsJsonPayload(BaseModel):
+    # OData filter naming the rows to update, e.g. "id eq 'a0468a96-...'".
+    # Required: an UPDATE with no WHERE rewrites the whole table, so omitting it
+    # is a schema violation rather than a check the controller has to remember.
+    filter: str
+    # Column -> new value.
+    data: Dict[str, Any]
+
+
+class TableUpdate(BaseModel):
+    table_name: str
+    # OData filter naming the rows to update in THIS table. Per-entry rather than
+    # shared: the tables are related, not identical, so one predicate could not
+    # address them all.
+    filter: str
+    data: Dict[str, Any]
+
+
+class UpdateRowsJsonMultiPayload(BaseModel):
+    updates: List[TableUpdate]
+    # Abort the whole transaction if any entry's filter matches nothing. The
+    # premise of an atomic multi-table update is that these rows move together,
+    # so a target that does not exist means the premise is false — committing the
+    # rest would leave the inconsistency the transaction was meant to prevent.
+    require_all_matched: bool = True
+
+
 class TableInsert(BaseModel):
     table_name: str
     # A single row dict if single_row=True, otherwise a list of row dicts.

--- a/wavefront/server/packages/flo_cloud/flo_cloud/postgres/__init__.py
+++ b/wavefront/server/packages/flo_cloud/flo_cloud/postgres/__init__.py
@@ -1,3 +1,3 @@
-from .postgres import PostgresClient
+from .postgres import NoRowsMatchedError, PostgresClient
 
-__all__ = ['PostgresClient']
+__all__ = ['NoRowsMatchedError', 'PostgresClient']

--- a/wavefront/server/packages/flo_cloud/flo_cloud/postgres/postgres.py
+++ b/wavefront/server/packages/flo_cloud/flo_cloud/postgres/postgres.py
@@ -11,6 +11,15 @@ from psycopg2 import sql
 logger = logging.getLogger(__name__)
 
 
+class NoRowsMatchedError(Exception):
+    """An atomic multi-table update had an entry whose filter matched nothing.
+
+    Distinct from a psycopg2 error: the statements were all valid and ran fine,
+    but one addressed a row that does not exist. The transaction is rolled back
+    before this is raised, so nothing was written.
+    """
+
+
 class PostgresClient:
     def __init__(
         self,
@@ -372,6 +381,155 @@ class PostgresClient:
             except psycopg2.Error as e:
                 conn.rollback()
                 logger.error(f'Insert error: {e}')
+                raise
+            finally:
+                cursor.close()
+
+    def _build_update(
+        self,
+        table_name: str,
+        data: Dict[str, Any],
+        where_clause: str,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> Tuple[Any, Dict[str, Any]]:
+        """Build the parameterized UPDATE and its merged parameters.
+
+        ``data`` maps column to new value, with dict/list values wrapped in
+        ``psycopg2.extras.Json`` exactly as ``_build_insert`` does — a jsonb column
+        needs it, or the value lands as a quoted text scalar.
+
+        ``where_clause`` is a parameterized predicate (from the OData parser) using
+        ``:name`` placeholders, and ``params`` holds its values. Both sides of the
+        statement share one parameter dict, so the SET placeholders are prefixed
+        ``set_``: the parser names its parameters after the field it filtered on,
+        and an unprefixed collision would silently feed one side of the statement
+        the other side's value.
+
+        An empty ``where_clause`` is refused. Callers should never construct one —
+        this is the last line of defence against an UPDATE that rewrites the whole
+        table.
+        """
+        if not data:
+            raise ValueError('No columns to update')
+        if not where_clause or not where_clause.strip():
+            raise ValueError('A where clause is required to update rows')
+
+        set_params = {
+            f'set_{col}': psycopg2.extras.Json(value)
+            if isinstance(value, (dict, list))
+            else value
+            for col, value in data.items()
+        }
+
+        # The parser emits ':name'; psycopg2 wants '%(name)s'. Convert the
+        # predicate on its own, then compose it in as a trusted SQL fragment.
+        converted_where, _ = self._convert_named_params(where_clause, params or {})
+
+        query = sql.SQL('UPDATE {table} SET {assignments} WHERE {where}').format(
+            table=sql.Identifier(*table_name.split('.')),
+            assignments=sql.SQL(', ').join(
+                sql.SQL('{col} = {val}').format(
+                    col=sql.Identifier(col), val=sql.Placeholder(name=f'set_{col}')
+                )
+                for col in data
+            ),
+            where=sql.SQL(converted_where),
+        )
+
+        return query, {**set_params, **(params or {})}
+
+    def update_rows_json(
+        self,
+        table_name: str,
+        data: Dict[str, Any],
+        where_clause: str,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> int:
+        """Update the rows matching ``where_clause``, returning how many changed."""
+        query, merged_params = self._build_update(
+            table_name, data, where_clause, params
+        )
+
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            try:
+                cursor.execute(query, merged_params)
+                updated_rows = cursor.rowcount
+                conn.commit()
+                return updated_rows
+            except psycopg2.Error as e:
+                conn.rollback()
+                logger.error(f'Update error: {e}')
+                raise
+            finally:
+                cursor.close()
+
+    def update_rows_json_multi(
+        self,
+        updates: List[Dict[str, Any]],
+        require_all_matched: bool = True,
+    ) -> List[Dict[str, Any]]:
+        """Update rows across multiple tables atomically, in one transaction.
+
+        ``updates`` is a list of
+        ``{"table_name": str, "data": Dict, "where_clause": str, "params": Dict}``.
+        All tables are written on one connection and committed once; any failure
+        rolls back every table (all-or-nothing).
+
+        ``require_all_matched`` is the reason this is not just a loop over
+        ``update_rows_json``. The single-table endpoint treats "matched 0 rows" as
+        a success, which is right when the caller may not know whether a row
+        exists. Here the whole premise is that these rows move *together*, so a
+        target that does not exist means the premise is false — committing the
+        other half would leave exactly the inconsistency the transaction was meant
+        to prevent. Default is therefore to roll back and raise; pass False for
+        best-effort semantics.
+
+        Returns one ``{"table_name": str, "updated_rows": int}`` per entry, in
+        order.
+        """
+        if not updates:
+            return []
+
+        prepared = [
+            (
+                spec['table_name'],
+                self._build_update(
+                    spec['table_name'],
+                    spec['data'],
+                    spec['where_clause'],
+                    spec.get('params'),
+                ),
+            )
+            for spec in updates
+        ]
+
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            try:
+                results = []
+                for table_name, (query, merged_params) in prepared:
+                    cursor.execute(query, merged_params)
+                    results.append(
+                        {'table_name': table_name, 'updated_rows': cursor.rowcount}
+                    )
+
+                if require_all_matched:
+                    unmatched = [
+                        r['table_name'] for r in results if not r['updated_rows']
+                    ]
+                    if unmatched:
+                        conn.rollback()
+                        raise NoRowsMatchedError(
+                            'No rows matched the filter for: '
+                            f'{", ".join(unmatched)}. Nothing was updated.'
+                        )
+
+                conn.commit()
+                return results
+            except psycopg2.Error as e:
+                conn.rollback()
+                logger.error(f'Multi-update error: {e}')
                 raise
             finally:
                 cursor.close()

--- a/wavefront/server/plugins/datasource/datasource/__init__.py
+++ b/wavefront/server/plugins/datasource/datasource/__init__.py
@@ -106,6 +106,52 @@ class DatasourcePlugin:
     def insert_rows_json_multi(self, inserts: List[Dict[str, Any]]):
         return self.datasource.insert_rows_json_multi(inserts)
 
+    def update_rows_json(
+        self, table_name: str, data: Dict[str, Any], filter: str
+    ) -> int:
+        """Update the rows matching the OData ``filter``, returning how many changed.
+
+        Unlike ``fetch_data``, which falls back to a '1=1' no-op predicate when no
+        filter is given, an absent or unparseable filter is an error here: an
+        UPDATE with no WHERE rewrites the whole table, so it must never be
+        reachable by omission.
+        """
+        where_clause, params = self.odata_parser.prepare_odata_filter(filter)
+        if not where_clause:
+            raise ValueError('A filter is required to update rows')
+        return self.datasource.update_rows_json(
+            table_name, data, where_clause, params or {}
+        )
+
+    def update_rows_json_multi(
+        self, updates: List[Dict[str, Any]], require_all_matched: bool = True
+    ) -> List[Dict[str, Any]]:
+        """Update rows across several tables atomically.
+
+        ``updates``: list of ``{"table_name", "data", "filter"}``, where ``filter``
+        is OData. Each entry carries its own filter — the tables are related, not
+        identical, so one predicate could not address them all.
+        """
+        prepared = []
+        for update in updates:
+            where_clause, params = self.odata_parser.prepare_odata_filter(
+                update.get('filter')
+            )
+            if not where_clause:
+                raise ValueError(
+                    'A filter is required to update rows, missing for table '
+                    f'{update.get("table_name")}'
+                )
+            prepared.append(
+                {
+                    'table_name': update['table_name'],
+                    'data': update['data'],
+                    'where_clause': where_clause,
+                    'params': params or {},
+                }
+            )
+        return self.datasource.update_rows_json_multi(prepared, require_all_matched)
+
     async def execute_query(
         self, query: str, use_legacy_sql: bool = False, dry_run: bool = False, **kwargs
     ) -> Any:

--- a/wavefront/server/plugins/datasource/datasource/postgres/__init__.py
+++ b/wavefront/server/plugins/datasource/datasource/postgres/__init__.py
@@ -65,6 +65,20 @@ class PostgresPlugin(DataSourceABC):
     def insert_rows_json_multi(self, inserts: List[Dict[str, Any]]) -> None:
         self.client.insert_rows_json_multi(inserts)
 
+    def update_rows_json(
+        self,
+        table_name: str,
+        data: Dict[str, Any],
+        where_clause: str,
+        params: Dict[str, Any],
+    ) -> int:
+        return self.client.update_rows_json(table_name, data, where_clause, params)
+
+    def update_rows_json_multi(
+        self, updates: List[Dict[str, Any]], require_all_matched: bool = True
+    ) -> List[Dict[str, Any]]:
+        return self.client.update_rows_json_multi(updates, require_all_matched)
+
     async def execute_query(
         self, query: str, use_legacy_sql: bool = False, dry_run: bool = False, **kwargs
     ) -> Any:

--- a/wavefront/server/plugins/datasource/datasource/types.py
+++ b/wavefront/server/plugins/datasource/datasource/types.py
@@ -94,6 +94,38 @@ class DataSourceABC(ABC):
             f'{type(self).__name__} does not support transactional multi-table insert'
         )
 
+    def update_rows_json(
+        self,
+        table_name: str,
+        data: Dict[str, Any],
+        where_clause: str,
+        params: Dict[str, Any],
+    ) -> int:
+        """Update the rows matching ``where_clause``, returning how many changed.
+
+        ``data`` maps column name to new value; ``where_clause`` is a parameterized
+        SQL predicate and ``params`` its values. Concrete (not abstract) with a
+        NotImplementedError default, for the same reason as
+        ``insert_rows_json_multi``: datasource types that don't support it stay
+        instantiable.
+        """
+        raise NotImplementedError(
+            f'{type(self).__name__} does not support updating rows'
+        )
+
+    def update_rows_json_multi(
+        self, updates: List[Dict[str, Any]], require_all_matched: bool = True
+    ) -> List[Dict[str, Any]]:
+        """Update rows across multiple tables atomically, in one transaction.
+
+        ``updates``: list of ``{"table_name", "data", "where_clause", "params"}``.
+        Concrete with a NotImplementedError default, for the same reason as
+        ``insert_rows_json_multi``.
+        """
+        raise NotImplementedError(
+            f'{type(self).__name__} does not support transactional multi-table update'
+        )
+
     @abstractmethod
     async def execute_dynamic_query(
         self,


### PR DESCRIPTION
- only for postgres for now

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API support for updating rows in a single table using required filters.
  * Added atomic updates across multiple tables with configurable matching requirements.
  * Update requests now return affected-row counts and aggregate results.
  * Added validation for filters, update data, and datasource availability.
* **Bug Fixes**
  * Added conflict handling when requested rows are not matched.
  * Multi-table updates roll back when required matches are not found or an error occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->