### PR TITLE
fix: param name collision in dynamic query execution

### DIFF
--- a/wavefront/server/plugins/datasource/datasource/__init__.py
+++ b/wavefront/server/plugins/datasource/datasource/__init__.py
@@ -168,9 +168,11 @@ class DatasourcePlugin:
         limit: Optional[int] = 100,
         params: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
-        odata_filter, odata_params = self.odata_parser.prepare_odata_filter(filter)
+        odata_filter, odata_params = self.odata_parser.prepare_odata_filter(
+            filter, param_prefix='flt_'
+        )
         odata_data_filter, odata_data_params = self.odata_parser.prepare_odata_filter(
-            rls_filter
+            rls_filter, param_prefix='rls_'
         )
         result_by_query: Dict[str, Any] = await self.datasource.execute_dynamic_query(
             query=query,

--- a/wavefront/server/plugins/datasource/datasource/odata_parser.py
+++ b/wavefront/server/plugins/datasource/datasource/odata_parser.py
@@ -217,7 +217,7 @@ class Lexer:
 class ODataParserABC(ABC):
     @abstractmethod
     def prepare_odata_filter(
-        self, filter_expr: Optional[str]
+        self, filter_expr: Optional[str], param_prefix: str = ''
     ) -> Tuple[Optional[str], Optional[Dict[str, Any]]]:
         pass
 
@@ -241,9 +241,9 @@ class ODataQueryParser:
             raise ValueError(f'Invalid type: {self.type}')
 
     def prepare_odata_filter(
-        self, odata_filter: Optional[str]
+        self, odata_filter: Optional[str], param_prefix: str = ''
     ) -> Tuple[Optional[str], Optional[Dict[str, Any]]]:
-        return self.parser.prepare_odata_filter(odata_filter)
+        return self.parser.prepare_odata_filter(odata_filter, param_prefix)
 
     def prepare_odata_joins(
         self, odata_joins: str, parent_table: str
@@ -254,12 +254,15 @@ class ODataQueryParser:
 class SQLFilterParser:
     """Unified parser for OData filter expressions and query parameters"""
 
-    def __init__(self, lexer: Lexer, dynamic_var_char: str = '@'):
+    def __init__(
+        self, lexer: Lexer, dynamic_var_char: str = '@', param_prefix: str = ''
+    ):
         self.lexer = lexer
         self.current_token = self.lexer.get_next_token()
         self.params = {}
         self.param_count = {}
         self.dynamic_var_char = dynamic_var_char
+        self.param_prefix = param_prefix
 
     def eat(self, token_type: TokenType):
         if self.current_token.type == token_type:
@@ -336,9 +339,9 @@ class SQLFilterParser:
         if '.' in field:
             # For table aliases like "a.id", use "a_id" as parameter key
             table_alias, column_name = field.split('.', 1)
-            base_param_key = f'{table_alias}_{column_name}'
+            base_param_key = f'{self.param_prefix}{table_alias}_{column_name}'
         else:
-            base_param_key = field
+            base_param_key = f'{self.param_prefix}{field}'
 
         if base_param_key in self.param_count:
             self.param_count[base_param_key] += 1
@@ -669,14 +672,20 @@ class SQLODataParser(ODataParserABC):
         self.dynamic_var_char = dynamic_var_char
 
     def prepare_odata_filter(
-        self, filter_expr: Optional[str]
+        self, filter_expr: Optional[str], param_prefix: str = ''
     ) -> Tuple[Optional[str], Optional[Dict[str, Any]]]:
-        """Parses an OData-like filter expression and converts it into a SQL-like query with parameters."""
+        """Parses an OData-like filter expression and converts it into a SQL-like query with parameters.
+
+        ``param_prefix`` namespaces the generated parameter names. Each call
+        restarts its own counter, so filters parsed separately but bound to the
+        same statement (e.g. ``$filter`` and an RLS filter) must be given
+        different prefixes or they will generate colliding names.
+        """
         if not filter_expr:
             return None, None
 
         lexer = Lexer(filter_expr)
-        parser = SQLFilterParser(lexer, self.dynamic_var_char)
+        parser = SQLFilterParser(lexer, self.dynamic_var_char, param_prefix)
 
         sql_expr = parser.parse_filter_expression()
 

--- a/wavefront/server/plugins/datasource/tests/test_odata_parser_lex.py
+++ b/wavefront/server/plugins/datasource/tests/test_odata_parser_lex.py
@@ -72,7 +72,7 @@ def test_date_comparison():
 
 def test_contains_operator():
     filter_expr = "description contains 'test'"
-    expected_sql = 'description LIKE @description'
+    expected_sql = 'LOWER(description) LIKE LOWER(@description)'
     expected_params = {'description': '%test%'}
     sql_expr, params = parser.prepare_odata_filter(filter_expr)
     assert sql_expr == expected_sql
@@ -179,7 +179,14 @@ def test_multiple_conditions_with_same_field_filling():
 
 def test_multiple_conditions_with_loan_amt():
     filter_expr = "created_at gt 2025-07-23T07:42:44 $and (loan_id contains '96444' $or branch contains '96444' $or region contains '96444' $or zone contains '96444' $or loan_amount eq '96444')"
-    expected_sql = "created_at > @created_at AND (loan_id LIKE '%96444%' OR branch LIKE '%96444%' OR region LIKE '%96444%' OR zone LIKE '%96444%' OR loan_amount = '96444')"
+    expected_sql = (
+        'created_at > @created_at AND ('
+        "LOWER(loan_id) LIKE LOWER('%96444%') OR "
+        "LOWER(branch) LIKE LOWER('%96444%') OR "
+        "LOWER(region) LIKE LOWER('%96444%') OR "
+        "LOWER(zone) LIKE LOWER('%96444%') OR "
+        "loan_amount = '96444')"
+    )
     sql_expr, params = parser.prepare_odata_filter(filter_expr)
     fill_odata = fill_odata_query(sql_expr, params)
     assert fill_odata == expected_sql
@@ -231,7 +238,10 @@ def test_join_filter_with_multiple_conditions():
 
 def test_join_filter_with_contains_operator():
     filter_expr = "a.name contains 'John' $and b.description contains 'test'"
-    expected_sql = 'a.name LIKE @a_name AND b.description LIKE @b_description'
+    expected_sql = (
+        'LOWER(a.name) LIKE LOWER(@a_name) '
+        'AND LOWER(b.description) LIKE LOWER(@b_description)'
+    )
     expected_params = {'a_name': '%John%', 'b_description': '%test%'}
     sql_expr, params = parser.prepare_odata_filter(filter_expr)
     assert sql_expr == expected_sql
@@ -254,3 +264,25 @@ def test_join_filter_with_same_field_different_tables():
     sql_expr, params = parser.prepare_odata_filter(filter_expr)
     assert sql_expr == expected_sql
     assert params == expected_params
+
+
+def test_param_prefix_namespaces_generated_names():
+    sql_expr, params = parser.prepare_odata_filter("region eq 'south'", 'flt_')
+    assert sql_expr == 'region = @flt_region'
+    assert params == {'flt_region': 'south'}
+
+
+def test_prefixes_keep_separately_parsed_filters_from_colliding():
+    filter_sql, filter_params = parser.prepare_odata_filter("region eq 'south'", 'flt_')
+    rls_sql, rls_params = parser.prepare_odata_filter(
+        "region eq 'north' $or region eq 'east'", 'rls_'
+    )
+
+    assert filter_sql == 'region = @flt_region'
+    assert rls_sql == 'region = @rls_region OR region = @rls_region_1'
+    assert not filter_params.keys() & rls_params.keys()
+    assert {**filter_params, **rls_params} == {
+        'flt_region': 'south',
+        'rls_region': 'north',
+        'rls_region_1': 'east',
+    }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved datasource query filtering by preventing parameter-name collisions between standard filters and row-level security filters.
  * Ensured text searches using `contains` are case-insensitive.
  * Improved handling of compound and joined filters for more reliable query results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->