### PR TITLE
feat: namespaced config store with fetch_configuration workflow node

### DIFF
--- a/wavefront/client/src/api/configuration-service.ts
+++ b/wavefront/client/src/api/configuration-service.ts
@@ -1,0 +1,64 @@
+import { IApiResponse } from '@app/lib/axios';
+import {
+  ConfigurationListData,
+  ConfigurationListItem,
+  ConfigurationListResponse,
+  ConfigurationResponse,
+  ConfigurationValue,
+  ConfigurationValueResponse,
+  CreateConfigurationRequest,
+  UpsertConfigurationRequest,
+} from '@app/types/configuration';
+import { AxiosInstance } from 'axios';
+
+/**
+ * Configurations are addressed by (namespace, key), so every path segment is
+ * encoded — a key may legitimately contain characters that would otherwise
+ * change the route.
+ */
+export class ConfigurationService {
+  constructor(private http: AxiosInstance) {}
+
+  async createConfiguration(data: CreateConfigurationRequest): Promise<ConfigurationResponse> {
+    const response: IApiResponse<ConfigurationListItem> = await this.http.post(
+      `/v1/:appId/floware/v1/configurations`,
+      data
+    );
+    return response;
+  }
+
+  /** Returns the configuration document itself, not a wrapper around it. */
+  async getConfiguration(namespace: string, key: string): Promise<ConfigurationValueResponse> {
+    const response: IApiResponse<ConfigurationValue> = await this.http.get(
+      `/v1/:appId/floware/v1/configurations/${encodeURIComponent(namespace)}/${encodeURIComponent(key)}`
+    );
+    return response;
+  }
+
+  /** Replaces the value wholesale — it is not merged into the stored document. */
+  async upsertConfiguration(
+    namespace: string,
+    key: string,
+    data: UpsertConfigurationRequest
+  ): Promise<ConfigurationResponse> {
+    const response: IApiResponse<ConfigurationListItem> = await this.http.put(
+      `/v1/:appId/floware/v1/configurations/${encodeURIComponent(namespace)}/${encodeURIComponent(key)}`,
+      data
+    );
+    return response;
+  }
+
+  async deleteConfiguration(namespace: string, key: string): Promise<ConfigurationResponse> {
+    const response: IApiResponse<ConfigurationListItem> = await this.http.delete(
+      `/v1/:appId/floware/v1/configurations/${encodeURIComponent(namespace)}/${encodeURIComponent(key)}`
+    );
+    return response;
+  }
+
+  async listConfigurations(namespace?: string): Promise<ConfigurationListResponse> {
+    const response: IApiResponse<ConfigurationListData> = await this.http.get(`/v1/:appId/floware/v1/configurations`, {
+      params: namespace ? { namespace } : undefined,
+    });
+    return response;
+  }
+}

--- a/wavefront/client/src/api/index.ts
+++ b/wavefront/client/src/api/index.ts
@@ -5,6 +5,7 @@ import { ApiServiceService } from './api-service-service';
 import { AppService } from './app-service';
 import { AppUserService } from './app-user-service';
 import { AuthenticatorService } from './authenticator-service';
+import { ConfigurationService } from './configuration-service';
 import { ConsoleAuthService } from './console-auth-service';
 import { DataPipelineService } from './data-pipeline-service';
 import { DatasourcesService } from './datasources-service';
@@ -47,6 +48,10 @@ class FloConsoleService {
 
   get authenticatorService() {
     return new AuthenticatorService(this.http);
+  }
+
+  get configurationService() {
+    return new ConfigurationService(this.http);
   }
 
   get consoleAuthService() {

--- a/wavefront/client/src/components/ConfigurationCard.tsx
+++ b/wavefront/client/src/components/ConfigurationCard.tsx
@@ -1,0 +1,34 @@
+import { ConfigurationListItem } from '@app/types/configuration';
+import React from 'react';
+import ResourceCard, { ResourceCardMetadata } from './ResourceCard';
+
+interface ConfigurationCardProps {
+  configuration: ConfigurationListItem;
+  onClick: (configuration: ConfigurationListItem) => void;
+  onDeleteClick: (e: React.MouseEvent, configuration: ConfigurationListItem) => void;
+}
+
+const ConfigurationCard: React.FC<ConfigurationCardProps> = ({ configuration, onClick, onDeleteClick }) => {
+  // The key is the title, so the namespace is what distinguishes two configs
+  // that share a key — it earns the metadata row ahead of the surrogate id.
+  const metadata: ResourceCardMetadata[] = [
+    {
+      label: 'Namespace',
+      value: configuration.namespace,
+      isMono: true,
+    },
+  ];
+
+  return (
+    <ResourceCard
+      title={configuration.key}
+      description={configuration.description}
+      metadata={metadata}
+      onClick={() => onClick(configuration)}
+      onDeleteClick={(e) => onDeleteClick(e, configuration)}
+      deleteTitle="Delete configuration"
+    />
+  );
+};
+
+export default ConfigurationCard;

--- a/wavefront/client/src/hooks/data/fetch-hooks.ts
+++ b/wavefront/client/src/hooks/data/fetch-hooks.ts
@@ -8,6 +8,7 @@ import { App } from '@app/types/app';
 import { Authenticator } from '@app/types/authenticator';
 import { Datasource, ReadYamlData, Yaml } from '@app/types/datasource';
 import { LLMInferenceConfig } from '@app/types/llm-inference-config';
+import { ConfigurationListItem, ConfigurationValue } from '@app/types/configuration';
 import { MessageProcessor, MessageProcessorListItem } from '@app/types/message-processor';
 import { Pipeline, PipelineFile, PipelineStatus } from '@app/types/pipeline';
 import { SttConfig } from '@app/types/stt-config';
@@ -44,6 +45,8 @@ import {
   getKnowledgeBasesQueryFn,
   getLLMConfigQueryFn,
   getLLMConfigsQueryFn,
+  getConfigurationQueryFn,
+  getConfigurationsQueryFn,
   getMessageProcessorQueryFn,
   getMessageProcessorsQueryFn,
   getModelQueryFn,
@@ -94,6 +97,8 @@ import {
   getKnowledgeBasesKey,
   getLLMConfigKey,
   getLLMConfigsKey,
+  getConfigurationKey,
+  getConfigurationsKey,
   getMessageProcessorKey,
   getMessageProcessorsKey,
   getModelKey,
@@ -401,6 +406,25 @@ export const useGetApiService = (
     getApiServiceKey(appId || '', serviceId || ''),
     () => getApiServiceQueryFn(serviceId!),
     !!appId && !!serviceId
+  );
+};
+
+export const useGetConfigurations = (
+  appId: string | undefined,
+  namespace?: string
+): UseQueryResult<ConfigurationListItem[], Error> => {
+  return useQueryInit(getConfigurationsKey(appId || '', namespace), () => getConfigurationsQueryFn(namespace), !!appId);
+};
+
+export const useGetConfiguration = (
+  appId: string | undefined,
+  namespace: string | undefined,
+  key: string | undefined
+): UseQueryResult<ConfigurationValue | null, Error> => {
+  return useQueryInit(
+    getConfigurationKey(appId || '', namespace || '', key || ''),
+    () => getConfigurationQueryFn(namespace!, key!),
+    !!appId && !!namespace && !!key
   );
 };
 

--- a/wavefront/client/src/hooks/data/query-functions.ts
+++ b/wavefront/client/src/hooks/data/query-functions.ts
@@ -5,6 +5,7 @@ import { NamespaceItem } from '@app/api/namespace-service';
 import { AgentApi, AgentListItem } from '@app/types/agent';
 import { ApiServiceItem } from '@app/types/api-service';
 import { Authenticator } from '@app/types/authenticator';
+import { ConfigurationListItem, ConfigurationValue } from '@app/types/configuration';
 import { Datasource, ReadYamlData, Yaml } from '@app/types/datasource';
 import { LLMInferenceConfig } from '@app/types/llm-inference-config';
 import { MessageProcessor, MessageProcessorListItem } from '@app/types/message-processor';
@@ -326,6 +327,23 @@ const getToolsQueryFn = async (): Promise<ToolDetails[]> => {
   return [];
 };
 
+const getConfigurationsQueryFn = async (namespace?: string): Promise<ConfigurationListItem[]> => {
+  const response = await floConsoleService.configurationService.listConfigurations(namespace);
+  if (response.data?.data?.configurations && Array.isArray(response.data.data.configurations)) {
+    return response.data.data.configurations;
+  }
+  return [];
+};
+
+/**
+ * Returns the configuration document. `null` means "not found"; an empty object
+ * is a legitimate stored value, so the two must not be conflated.
+ */
+const getConfigurationQueryFn = async (namespace: string, key: string): Promise<ConfigurationValue | null> => {
+  const response = await floConsoleService.configurationService.getConfiguration(namespace, key);
+  return response.data?.data ?? null;
+};
+
 const getMessageProcessorsQueryFn = async (): Promise<MessageProcessorListItem[]> => {
   const response = await floConsoleService.messageProcessorService.listMessageProcessors();
   if (response.data?.data?.processors && Array.isArray(response.data.data.processors)) {
@@ -480,6 +498,8 @@ export {
   getLLMConfigQueryFn,
   getLLMConfigsQueryFn,
   getMessageProcessorQueryFn,
+  getConfigurationQueryFn,
+  getConfigurationsQueryFn,
   getMessageProcessorsQueryFn,
   getModelQueryFn,
   getModelsQueryFn,

--- a/wavefront/client/src/hooks/data/query-keys.ts
+++ b/wavefront/client/src/hooks/data/query-keys.ts
@@ -54,6 +54,9 @@ const getAgentVersionsKey = (appId: string, agentId: string) => ['agent-versions
 const getWorkflowVersionsKey = (appId: string, workflowId: string) => ['workflow-versions', appId, workflowId];
 const getToolsKey = (appId: string) => ['tools', appId];
 const getApiServiceKey = (appId: string, serviceId: string) => ['api-service', appId, serviceId];
+const getConfigurationsKey = (appId: string, namespace?: string) =>
+  namespace ? ['configurations', appId, namespace] : ['configurations', appId];
+const getConfigurationKey = (appId: string, namespace: string, key: string) => ['configuration', appId, namespace, key];
 const getMessageProcessorsKey = (appId: string) => ['message-processors', appId];
 const getMessageProcessorKey = (appId: string, processorId: string) => ['message-processor', appId, processorId];
 const getPipelinesKey = (appId: string, statusFilter?: string) => {
@@ -96,6 +99,8 @@ export {
   getKnowledgeBasesKey,
   getLLMConfigKey,
   getLLMConfigsKey,
+  getConfigurationKey,
+  getConfigurationsKey,
   getMessageProcessorKey,
   getMessageProcessorsKey,
   getModelKey,

--- a/wavefront/client/src/pages/apps/[appId]/configurations/CreateConfigurationDialog.tsx
+++ b/wavefront/client/src/pages/apps/[appId]/configurations/CreateConfigurationDialog.tsx
@@ -30,7 +30,7 @@ import { z } from 'zod';
 
 const createConfigurationSchema = z.object({
   namespace: z.string().min(1, 'Namespace is required'),
-  key: z.string().min(1, 'Key is required'),
+  key: z.string().trim().min(1, 'Key is required'),
   description: z.string().optional(),
   // Validated here rather than server-side so the editor can point at the
   // problem while the document is still in front of the user.

--- a/wavefront/client/src/pages/apps/[appId]/configurations/CreateConfigurationDialog.tsx
+++ b/wavefront/client/src/pages/apps/[appId]/configurations/CreateConfigurationDialog.tsx
@@ -1,0 +1,238 @@
+import floConsoleService from '@app/api';
+import { Button } from '@app/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@app/components/ui/dialog';
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@app/components/ui/form';
+import { Input } from '@app/components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@app/components/ui/select';
+import { useGetNamespaces } from '@app/hooks';
+import { useNotifyStore } from '@app/store';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { langs } from '@uiw/codemirror-extensions-langs';
+import CodeMirror from '@uiw/react-codemirror';
+import React, { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+const createConfigurationSchema = z.object({
+  namespace: z.string().min(1, 'Namespace is required'),
+  key: z.string().min(1, 'Key is required'),
+  description: z.string().optional(),
+  // Validated here rather than server-side so the editor can point at the
+  // problem while the document is still in front of the user.
+  value: z
+    .string()
+    .min(1, 'Value is required')
+    .refine((raw) => {
+      try {
+        JSON.parse(raw);
+        return true;
+      } catch {
+        return false;
+      }
+    }, 'Value must be valid JSON'),
+});
+
+type CreateConfigurationInput = z.infer<typeof createConfigurationSchema>;
+
+const defaultValue = `{
+  "enabled": true,
+  "limits": {
+    "daily": 5000
+  }
+}`;
+
+interface CreateConfigurationDialogProps {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  appId: string;
+  onSuccess?: () => void;
+}
+
+const CreateConfigurationDialog: React.FC<CreateConfigurationDialogProps> = ({
+  isOpen,
+  onOpenChange,
+  appId,
+  onSuccess,
+}) => {
+  const { notifySuccess, notifyError } = useNotifyStore();
+  // A dropdown rather than a text field: the server rejects a namespace that
+  // does not exist, so offering only real ones turns a 400 into an impossible
+  // choice.
+  const { data: namespaces = [] } = useGetNamespaces(appId);
+
+  const form = useForm<CreateConfigurationInput>({
+    resolver: zodResolver(createConfigurationSchema),
+    defaultValues: {
+      namespace: '',
+      key: '',
+      description: '',
+      value: defaultValue,
+    },
+  });
+
+  useEffect(() => {
+    if (!isOpen) {
+      form.reset({
+        namespace: '',
+        key: '',
+        description: '',
+        value: defaultValue,
+      });
+    }
+  }, [isOpen, form]);
+
+  const onSubmit = async (data: CreateConfigurationInput) => {
+    try {
+      const response = await floConsoleService.configurationService.createConfiguration({
+        namespace: data.namespace,
+        key: data.key.trim(),
+        value: JSON.parse(data.value),
+        description: data.description?.trim() || undefined,
+      });
+
+      if (response.data) {
+        notifySuccess('Configuration created successfully');
+        onSuccess?.();
+        onOpenChange(false);
+      } else {
+        notifyError('Failed to create configuration');
+      }
+    } catch (error) {
+      console.error('Error creating configuration:', error);
+    }
+  };
+
+  if (!appId) {
+    return null;
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[90vh] max-w-4xl overflow-y-auto lg:max-w-4xl">
+        <DialogHeader>
+          <DialogTitle>Create New Configuration</DialogTitle>
+          <DialogDescription>Static reference data workflows read at runtime</DialogDescription>
+        </DialogHeader>
+
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+            <div className="grid grid-cols-3 gap-6">
+              <FormField
+                control={form.control}
+                name="namespace"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      Namespace<span className="text-red-500">*</span>
+                    </FormLabel>
+                    <Select onValueChange={field.onChange} value={field.value}>
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select namespace" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {namespaces.map((namespace) => (
+                          <SelectItem key={namespace.name} value={namespace.name}>
+                            {namespace.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="key"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      Key<span className="text-red-500">*</span>
+                    </FormLabel>
+                    <FormControl>
+                      <Input placeholder="e.g. thresholds" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="description"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Description</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Optional" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <FormField
+              control={form.control}
+              name="value"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    Value<span className="text-red-500">*</span>
+                  </FormLabel>
+                  <FormControl>
+                    <div className="w-full">
+                      <CodeMirror
+                        value={field.value}
+                        onChange={field.onChange}
+                        theme="dark"
+                        height="400px"
+                        className="w-full"
+                        extensions={[langs.json()]}
+                        placeholder="Enter the configuration document as JSON..."
+                      />
+                    </div>
+                  </FormControl>
+                  <FormDescription>
+                    Any JSON document. A workflow reads it with a <code>fetch_configuration</code> node and passes it to
+                    a function for calculations.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+                Cancel
+              </Button>
+              <Button type="submit" loading={form.formState.isSubmitting}>
+                Create Configuration
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default CreateConfigurationDialog;

--- a/wavefront/client/src/pages/apps/[appId]/configurations/[configKey].tsx
+++ b/wavefront/client/src/pages/apps/[appId]/configurations/[configKey].tsx
@@ -1,0 +1,176 @@
+import floConsoleService from '@app/api';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbSeparator,
+} from '@app/components/ui/breadcrumb';
+import { Button } from '@app/components/ui/button';
+import { Input } from '@app/components/ui/input';
+import { Label } from '@app/components/ui/label';
+import { useGetConfiguration, useGetConfigurations } from '@app/hooks';
+import { getConfigurationKey, getConfigurationsKey } from '@app/hooks/data/query-keys';
+import { useNotifyStore } from '@app/store';
+import { useQueryClient } from '@tanstack/react-query';
+import { langs } from '@uiw/codemirror-extensions-langs';
+import CodeMirror from '@uiw/react-codemirror';
+import React, { useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router';
+
+const ConfigurationDetail: React.FC = () => {
+  const { app: appId, namespace, configKey } = useParams<{ app: string; namespace: string; configKey: string }>();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { notifySuccess, notifyError } = useNotifyStore();
+
+  const [valueText, setValueText] = useState('');
+  const [description, setDescription] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const { data: value, isLoading: loadingValue } = useGetConfiguration(appId, namespace, configKey);
+
+  // The detail endpoint returns the configuration document alone — it is the
+  // same endpoint the workflow node calls, and that node's output has to be the
+  // document. Description therefore comes from the list, which carries metadata
+  // but no values. Saving is blocked until it has loaded, because PUT replaces
+  // description too: sending an empty one before it arrives would silently wipe
+  // it.
+  const { data: configurations = [], isLoading: loadingMetadata } = useGetConfigurations(appId);
+  const metadata = useMemo(
+    () => configurations.find((item) => item.namespace === namespace && item.key === configKey),
+    [configurations, namespace, configKey]
+  );
+
+  useEffect(() => {
+    if (value !== undefined && value !== null) {
+      setValueText(JSON.stringify(value, null, 2));
+    }
+  }, [value]);
+
+  useEffect(() => {
+    setDescription(metadata?.description ?? '');
+  }, [metadata]);
+
+  const parseError = useMemo(() => {
+    if (!valueText.trim()) return 'Value is required';
+    try {
+      JSON.parse(valueText);
+      return null;
+    } catch (error) {
+      return error instanceof Error ? error.message : 'Value must be valid JSON';
+    }
+  }, [valueText]);
+
+  const handleSave = async () => {
+    if (!namespace || !configKey || parseError) return;
+
+    setSaving(true);
+    try {
+      const response = await floConsoleService.configurationService.upsertConfiguration(namespace, configKey, {
+        value: JSON.parse(valueText),
+        description: description.trim() || undefined,
+      });
+
+      if (response.data) {
+        notifySuccess('Configuration saved successfully');
+        queryClient.invalidateQueries({
+          queryKey: getConfigurationKey(appId || '', namespace, configKey),
+        });
+        queryClient.invalidateQueries({
+          queryKey: getConfigurationsKey(appId || ''),
+        });
+      } else {
+        notifyError('Failed to save configuration');
+      }
+    } catch (error) {
+      console.error('Error saving configuration:', error);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const loading = loadingValue || loadingMetadata;
+
+  return (
+    <div className="flex h-full w-full flex-col p-8">
+      <Breadcrumb className="mb-4">
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <button type="button" onClick={() => navigate('/apps')} className="hover:text-foreground cursor-pointer">
+                Apps
+              </button>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <button
+                type="button"
+                onClick={() => navigate(`/apps/${appId}/configurations`)}
+                className="hover:text-foreground cursor-pointer"
+              >
+                Configurations
+              </button>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>{configKey}</BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+
+      <div className="mb-8 flex w-full items-start justify-between">
+        <div>
+          <h1 className="animate-fade-in text-3xl font-bold text-gray-900">{configKey}</h1>
+          <p className="animate-fade-in mt-2 font-mono text-sm text-gray-600">{namespace}</p>
+        </div>
+        <div className="animate-fade-in flex items-center gap-4">
+          <Button variant="outline" onClick={() => navigate(`/apps/${appId}/configurations`)}>
+            Back
+          </Button>
+          <Button onClick={handleSave} loading={saving} disabled={!!parseError || loading}>
+            Save
+          </Button>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-6 overflow-y-auto">
+        <div className="max-w-xl">
+          <Label htmlFor="configuration-description">Description</Label>
+          <Input
+            id="configuration-description"
+            className="mt-2"
+            placeholder="Optional"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            disabled={loading}
+          />
+        </div>
+
+        <div>
+          <Label>Value</Label>
+          <p className="mt-1 mb-2 text-sm text-gray-600">
+            Replaced wholesale on save — the document is not merged into the stored one, so removing a field here
+            removes it in storage.
+          </p>
+          {loading ? (
+            <div className="h-[500px] w-full animate-pulse rounded-md bg-gray-100" />
+          ) : (
+            <CodeMirror
+              value={valueText}
+              onChange={setValueText}
+              theme="dark"
+              height="500px"
+              className="w-full"
+              extensions={[langs.json()]}
+            />
+          )}
+          {parseError && <p className="mt-2 text-sm text-red-500">{parseError}</p>}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ConfigurationDetail;

--- a/wavefront/client/src/pages/apps/[appId]/configurations/index.tsx
+++ b/wavefront/client/src/pages/apps/[appId]/configurations/index.tsx
@@ -1,0 +1,183 @@
+import floConsoleService from '@app/api';
+import ConfigurationCard from '@app/components/ConfigurationCard';
+import DeleteConfirmationDialog from '@app/components/DeleteConfirmationDialog';
+import { EmptyStateCard } from '@app/components/EmptyCard';
+import { ResourceCardSkeleton } from '@app/components/ResourceCard';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbSeparator,
+} from '@app/components/ui/breadcrumb';
+import { Button } from '@app/components/ui/button';
+import { Input } from '@app/components/ui/input';
+import { useGetConfigurations } from '@app/hooks';
+import { getConfigurationsKey } from '@app/hooks/data/query-keys';
+import { useNotifyStore } from '@app/store';
+import { ConfigurationListItem } from '@app/types/configuration';
+import { useQueryClient } from '@tanstack/react-query';
+import React, { useState } from 'react';
+import { useNavigate, useParams } from 'react-router';
+import CreateConfigurationDialog from './CreateConfigurationDialog';
+
+const ConfigurationsManagement: React.FC = () => {
+  const { app: appId } = useParams<{ app: string }>();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [searchTerm, setSearchTerm] = useState('');
+  const [deleteItem, setDeleteItem] = useState<ConfigurationListItem | null>(null);
+  const [deleting, setDeleting] = useState(false);
+  const [createDialogOpen, setCreateDialogOpen] = useState(false);
+
+  const { notifySuccess } = useNotifyStore();
+
+  const { data: configurations = [], isLoading: loading } = useGetConfigurations(appId);
+
+  const filteredConfigurations = configurations.filter(
+    (configuration) =>
+      configuration.key.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      configuration.namespace.toLowerCase().includes(searchTerm.toLowerCase())
+  );
+
+  const invalidate = () =>
+    queryClient.invalidateQueries({
+      queryKey: getConfigurationsKey(appId || ''),
+    });
+
+  const handleCreateConfiguration = () => {
+    setCreateDialogOpen(true);
+  };
+
+  const handleCreateSuccess = () => {
+    invalidate();
+    setCreateDialogOpen(false);
+  };
+
+  const handleConfigurationClick = (configuration: ConfigurationListItem) => {
+    navigate(
+      `/apps/${appId}/configurations/${encodeURIComponent(configuration.namespace)}/${encodeURIComponent(
+        configuration.key
+      )}`
+    );
+  };
+
+  const handleDeleteClick = (e: React.MouseEvent, configuration: ConfigurationListItem) => {
+    e.stopPropagation();
+    setDeleteItem(configuration);
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!deleteItem) return;
+
+    setDeleting(true);
+    try {
+      await floConsoleService.configurationService.deleteConfiguration(deleteItem.namespace, deleteItem.key);
+      notifySuccess('Configuration deleted successfully');
+      invalidate();
+      setDeleteItem(null);
+    } catch (error) {
+      console.error('Error deleting configuration:', error);
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  const handleDeleteCancel = () => {
+    setDeleteItem(null);
+  };
+
+  return (
+    <div className="flex h-full w-full flex-col p-8">
+      <Breadcrumb className="mb-4">
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <button type="button" onClick={() => navigate('/apps')} className="hover:text-foreground cursor-pointer">
+                Apps
+              </button>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <button
+                type="button"
+                onClick={() => navigate(`/apps/${appId}/configurations`)}
+                className="hover:text-foreground cursor-pointer"
+              >
+                Configurations
+              </button>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+
+      <div className="mb-8 flex w-full items-start justify-between">
+        <div>
+          <h1 className="animate-fade-in text-3xl font-bold text-gray-900">Configurations</h1>
+          <p className="animate-fade-in mt-2 text-gray-600">Static reference data workflows read at runtime</p>
+        </div>
+        <div className="animate-fade-in flex items-center gap-4">
+          <Input
+            className="w-[180px]"
+            type="text"
+            placeholder="Search"
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+          />
+          <Button onClick={handleCreateConfiguration}>Create Configuration</Button>
+        </div>
+      </div>
+      <div className="grid gap-6 overflow-y-auto py-2 sm:grid-cols-2 lg:grid-cols-3">
+        {loading ? (
+          <>
+            {Array.from({ length: 6 }).map((_, index) => (
+              <ResourceCardSkeleton key={index} showDescription metadataCount={1} />
+            ))}
+          </>
+        ) : filteredConfigurations.length === 0 ? (
+          <div className="col-span-full mt-10 flex justify-center">
+            <EmptyStateCard
+              title="No configurations found"
+              description="Get started by creating your first configuration"
+              actionText="Create Configuration"
+              onActionClick={handleCreateConfiguration}
+            />
+          </div>
+        ) : (
+          <>
+            {filteredConfigurations.map((configuration) => (
+              <ConfigurationCard
+                key={configuration.id}
+                configuration={configuration}
+                onClick={handleConfigurationClick}
+                onDeleteClick={handleDeleteClick}
+              />
+            ))}
+          </>
+        )}
+      </div>
+
+      <DeleteConfirmationDialog
+        isOpen={!!deleteItem}
+        title="Delete Configuration"
+        message={`Are you sure you want to delete "${deleteItem?.key}" from namespace "${deleteItem?.namespace}"? Any workflow reading it will start failing. This action cannot be undone.`}
+        onConfirm={handleDeleteConfirm}
+        onCancel={handleDeleteCancel}
+        loading={deleting}
+      />
+
+      {appId && (
+        <CreateConfigurationDialog
+          isOpen={createDialogOpen}
+          onOpenChange={setCreateDialogOpen}
+          appId={appId}
+          onSuccess={handleCreateSuccess}
+        />
+      )}
+    </div>
+  );
+};
+
+export default ConfigurationsManagement;

--- a/wavefront/client/src/pages/apps/layout.tsx
+++ b/wavefront/client/src/pages/apps/layout.tsx
@@ -30,6 +30,13 @@ const navItems = [
     description: 'Manage authentication provider configurations',
   },
   {
+    id: 'configurations',
+    name: 'Configurations',
+    icon: ModelRepositoryIcon,
+    link: `/apps/:appId/configurations`,
+    description: 'Static reference data workflows read at runtime',
+  },
+  {
     id: 'datasources',
     name: 'Datasources',
     icon: DatasourcesIcon,

--- a/wavefront/client/src/router/routes.tsx
+++ b/wavefront/client/src/router/routes.tsx
@@ -8,6 +8,8 @@ import AuthenticatorDetailPage from '@app/pages/apps/[appId]/authenticators/[aut
 import DatasourcesManagement from '@app/pages/apps/[appId]/datasources';
 import DatasourceDetail from '@app/pages/apps/[appId]/datasources/[datasourceId]';
 import ScheduledJobsPage from '@app/pages/apps/[appId]/scheduled-jobs';
+import ConfigurationsManagement from '@app/pages/apps/[appId]/configurations';
+import ConfigurationDetail from '@app/pages/apps/[appId]/configurations/[configKey]';
 import FunctionsManagement from '@app/pages/apps/[appId]/functions';
 import FunctionDetail from '@app/pages/apps/[appId]/functions/[functionId]';
 import KnowledgeBaseDetailPage from '@app/pages/apps/[appId]/knowledge-bases/[kbId]';
@@ -149,6 +151,14 @@ const routes = {
         {
           path: 'workflows/pipelines/:workflowPipelineId',
           element: <WorkflowPipelineDetail />,
+        },
+        {
+          path: 'configurations',
+          element: <ConfigurationsManagement />,
+        },
+        {
+          path: 'configurations/:namespace/:configKey',
+          element: <ConfigurationDetail />,
         },
         {
           path: 'functions',

--- a/wavefront/client/src/types/configuration.ts
+++ b/wavefront/client/src/types/configuration.ts
@@ -1,0 +1,43 @@
+import { IApiResponse } from '@app/lib/axios';
+
+/**
+ * Runtime configuration: static reference data a workflow reads at execution
+ * time (thresholds, limits, lookup tables). Addressed by
+ * (namespace, key); `id` is a surrogate and no endpoint uses it.
+ */
+export interface ConfigurationListItem {
+  id: string;
+  namespace: string;
+  key: string;
+  description?: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface ConfigurationListData {
+  configurations: ConfigurationListItem[];
+}
+
+export interface CreateConfigurationRequest {
+  namespace: string;
+  key: string;
+  /** Arbitrary JSON document — the server never interprets it. */
+  value: unknown;
+  description?: string;
+}
+
+export interface UpsertConfigurationRequest {
+  value: unknown;
+  description?: string;
+}
+
+/**
+ * The detail read returns the configuration document itself, not a wrapper —
+ * it is the same endpoint the `fetch_configuration` workflow node calls, and
+ * that node's output has to be the document.
+ */
+export type ConfigurationValue = unknown;
+
+export type ConfigurationResponse = IApiResponse<ConfigurationListItem>;
+export type ConfigurationValueResponse = IApiResponse<ConfigurationValue>;
+export type ConfigurationListResponse = IApiResponse<ConfigurationListData>;

--- a/wavefront/server/apps/floware/floware/server.py
+++ b/wavefront/server/apps/floware/floware/server.py
@@ -54,6 +54,7 @@ from floware.di.application_container import ApplicationContainer
 from floware.middleware.security_headers import SecurityHeadersMiddleware
 from floware.services.scheduler_manager import SchedulerManager
 from plugins_module.plugins_container import PluginsContainer
+from plugins_module.controllers.configuration_controller import configuration_router
 from plugins_module.controllers.datasource_controller import datasource_router
 from plugins_module.controllers.authenticator_controller import authenticator_router
 from floware.controllers.config_controller import config_router
@@ -151,6 +152,8 @@ plugins_container = PluginsContainer(
     cloud_storage_manager=common_container.cloud_storage_manager,
     dynamic_query_repository=db_repo_container.dynamic_query_repository,
     cache_manager=db_repo_container.cache_manager,
+    namespace_repository=db_repo_container.namespace_repository,
+    agentic_configuration_repository=db_repo_container.agentic_configuration_repository,
 )
 
 product_analysis_container = ProductAnalysisContainer()
@@ -450,6 +453,7 @@ app.include_router(stt_config_router, prefix='/floware')
 app.include_router(voice_agent_router, prefix='/floware')
 app.include_router(tool_router, prefix='/floware')
 app.include_router(message_processor_router, prefix='/floware')
+app.include_router(configuration_router, prefix='/floware')
 app.include_router(cloud_storage_router, prefix='/floware')
 app.include_router(trigger_router, prefix='/floware')
 

--- a/wavefront/server/modules/db_repo_module/db_repo_module/alembic/env.py
+++ b/wavefront/server/modules/db_repo_module/db_repo_module/alembic/env.py
@@ -37,6 +37,7 @@ from db_repo_module.models.scheduled_job import ScheduledJob
 from db_repo_module.models.scheduled_job_execution import ScheduledJobExecution
 from db_repo_module.models.async_agentic_execution import AsyncAgenticExecution
 from db_repo_module.models.agentic_trigger_credential import AgenticTriggerCredential
+from db_repo_module.models.agentic_configuration import AgenticConfiguration
 from db_repo_module.models.agentic_trigger import AgenticTrigger
 from db_repo_module.models.agentic_trigger_event import AgenticTriggerEvent
 from db_repo_module.models.agent import Agent
@@ -91,6 +92,7 @@ models = [
     ScheduledJob,
     ScheduledJobExecution,
     AsyncAgenticExecution,
+    AgenticConfiguration,
     AgenticTriggerCredential,
     AgenticTrigger,
     AgenticTriggerEvent,

--- a/wavefront/server/modules/db_repo_module/db_repo_module/alembic/versions/2026_08_04_1030-c7e2a1b4d9f3_create_agentic_configurations_table.py
+++ b/wavefront/server/modules/db_repo_module/db_repo_module/alembic/versions/2026_08_04_1030-c7e2a1b4d9f3_create_agentic_configurations_table.py
@@ -1,0 +1,60 @@
+"""create agentic_configurations table
+
+Revision ID: c7e2a1b4d9f3
+Revises: 1d6a0d5cfd6f
+Create Date: 2026-08-04 10:30:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = 'c7e2a1b4d9f3'
+down_revision: Union[str, None] = '1d6a0d5cfd6f'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'agentic_configurations',
+        sa.Column('id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('namespace', sa.String(length=255), nullable=False),
+        sa.Column('key', sa.String(length=255), nullable=False),
+        sa.Column('value', postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column('description', sa.Text(), nullable=True),
+        sa.Column(
+            'created_at', sa.DateTime(), nullable=False, server_default=sa.func.now()
+        ),
+        sa.Column(
+            'updated_at', sa.DateTime(), nullable=False, server_default=sa.func.now()
+        ),
+        sa.ForeignKeyConstraint(['namespace'], ['namespaces.name']),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint(
+            'namespace', 'key', name='uq_agentic_configurations_namespace_key'
+        ),
+    )
+    op.create_index(
+        op.f('ix_agentic_configurations_id'), 'agentic_configurations', ['id']
+    )
+    op.create_index(
+        op.f('ix_agentic_configurations_namespace'),
+        'agentic_configurations',
+        ['namespace'],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f('ix_agentic_configurations_namespace'),
+        table_name='agentic_configurations',
+    )
+    op.drop_index(
+        op.f('ix_agentic_configurations_id'), table_name='agentic_configurations'
+    )
+    op.drop_table('agentic_configurations')

--- a/wavefront/server/modules/db_repo_module/db_repo_module/cache/cache_manager.py
+++ b/wavefront/server/modules/db_repo_module/db_repo_module/cache/cache_manager.py
@@ -151,11 +151,20 @@ class CacheManager(CommonCache):
         value = self.get_str(key, default)
         return int(value) if value is not None else default
 
+    # Retries on the same terms as add()/get_str(). A dropped delete is the one
+    # failure that outlives the request: the key keeps serving the pre-write
+    # value until its TTL expires, so a transient blip here means stale reads
+    # long after the blip is over.
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=1, max=10),
+        retry=retry_if_exception_type((RedisError, ConnectionError, TimeoutError)),
+    )
     def remove(self, key: str) -> bool:
         try:
             return bool(self.redis.delete(f'{self.namespace}/{key}'))
         except (RedisError, ConnectionError, TimeoutError) as e:
-            logger.error(f'Error getting key: {key} from cache: {e}')
+            logger.error(f'Error removing key: {key} from cache: {e}')
             raise
 
     def invalidate_query(self, pattern: str) -> int:

--- a/wavefront/server/modules/db_repo_module/db_repo_module/db_repo_container.py
+++ b/wavefront/server/modules/db_repo_module/db_repo_module/db_repo_container.py
@@ -18,6 +18,7 @@ from db_repo_module.models.user import User
 from db_repo_module.models.user_role import UserRole
 from db_repo_module.models.product_analytics import ProductAnalytics
 from db_repo_module.models.session import Session
+from db_repo_module.models.agentic_configuration import AgenticConfiguration
 from db_repo_module.models.config import Config
 from db_repo_module.models.dynamic_query_yaml import DynamicQueryYaml
 from db_repo_module.models.model_schema import ModelSchema
@@ -198,6 +199,12 @@ class DatabaseModuleContainer(containers.DeclarativeContainer):
     namespace_repository = providers.Singleton(
         SQLAlchemyRepository[Namespace],
         model=Namespace,
+        db_client=db_client,
+    )
+
+    agentic_configuration_repository = providers.Singleton(
+        SQLAlchemyRepository[AgenticConfiguration],
+        model=AgenticConfiguration,
         db_client=db_client,
     )
 

--- a/wavefront/server/modules/db_repo_module/db_repo_module/models/agentic_configuration.py
+++ b/wavefront/server/modules/db_repo_module/db_repo_module/models/agentic_configuration.py
@@ -1,0 +1,59 @@
+import uuid
+from datetime import datetime
+from typing import Any, Optional
+
+from sqlalchemy import ForeignKey, String, Text, UniqueConstraint, func
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from ..database.base import Base
+
+
+class AgenticConfiguration(Base):
+    """Static reference data read at workflow execution time.
+
+    Thresholds, limits, lookup tables — anything a deterministic step needs but
+    should not have baked into its code or sent on every request.
+    `value` is an arbitrary JSON document; wavefront never interprets it.
+
+    Distinct from the `config` table, which holds the app's own white-labelling
+    settings under a single flat key.
+    """
+
+    __tablename__ = 'agentic_configurations'
+    __table_args__ = (
+        UniqueConstraint(
+            'namespace', 'key', name='uq_agentic_configurations_namespace_key'
+        ),
+    )
+
+    # Surrogate. Lookups address a row by (namespace, key); this exists so a
+    # config can be referenced stably if its key is ever renamed.
+    id: Mapped[uuid.UUID] = mapped_column(
+        primary_key=True, default=uuid.uuid4, index=True
+    )
+    namespace: Mapped[str] = mapped_column(
+        ForeignKey('namespaces.name'), nullable=False, index=True
+    )
+    key: Mapped[str] = mapped_column(String(length=255), nullable=False)
+    value: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
+    description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        default=func.now(), onupdate=func.now()
+    )
+
+    @staticmethod
+    def get_table_name():
+        return AgenticConfiguration.__tablename__
+
+    def to_dict(self):
+        return {
+            'id': str(self.id),
+            'namespace': self.namespace,
+            'key': self.key,
+            'value': self.value,
+            'description': self.description,
+            'created_at': self.created_at.isoformat(),
+            'updated_at': self.updated_at.isoformat(),
+        }

--- a/wavefront/server/modules/plugins_module/plugins_module/controllers/configuration_controller.py
+++ b/wavefront/server/modules/plugins_module/plugins_module/controllers/configuration_controller.py
@@ -20,6 +20,8 @@ from plugins_module.plugins_container import PluginsContainer
 from plugins_module.services.configuration_service import (
     ConfigurationAlreadyExistsError,
     ConfigurationService,
+    InvalidConfigurationKeyError,
+    InvalidConfigurationValueError,
     NamespaceNotFoundError,
 )
 
@@ -57,7 +59,11 @@ async def create_configuration(
             value=payload.value,
             description=payload.description,
         )
-    except NamespaceNotFoundError as e:
+    except (
+        NamespaceNotFoundError,
+        InvalidConfigurationKeyError,
+        InvalidConfigurationValueError,
+    ) as e:
         return JSONResponse(
             status_code=status.HTTP_400_BAD_REQUEST,
             content=response_formatter.buildErrorResponse(str(e)),
@@ -113,6 +119,9 @@ async def get_configuration(
     This is the read path the `fetch_configuration` function node uses on every
     workflow run, so the body is the document and nothing else.
     """
+    # None means no such row: a null document is refused on write, so it can
+    # never be a stored value. Other falsy documents (0, "", [], {}) are real
+    # values and fall through to the 200 below.
     value = await configuration_service.get_value(namespace, key)
     if value is None:
         return JSONResponse(
@@ -153,7 +162,11 @@ async def upsert_configuration(
             value=payload.value,
             description=payload.description,
         )
-    except NamespaceNotFoundError as e:
+    except (
+        NamespaceNotFoundError,
+        InvalidConfigurationKeyError,
+        InvalidConfigurationValueError,
+    ) as e:
         return JSONResponse(
             status_code=status.HTTP_400_BAD_REQUEST,
             content=response_formatter.buildErrorResponse(str(e)),

--- a/wavefront/server/modules/plugins_module/plugins_module/controllers/configuration_controller.py
+++ b/wavefront/server/modules/plugins_module/plugins_module/controllers/configuration_controller.py
@@ -1,0 +1,194 @@
+"""
+Controller for the namespaced runtime configuration store.
+
+Holds static reference data that deterministic workflow steps read at execution
+time — thresholds, limits, lookup tables. Configurations are
+addressed by (namespace, key); the row's `id` is a surrogate and no route uses
+it, which also keeps `/{namespace}` unambiguous.
+"""
+
+from typing import Any, Optional
+
+from dependency_injector.wiring import inject, Provide
+from fastapi import APIRouter, Depends, Query, status
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from common_module.common_container import CommonContainer
+from common_module.response_formatter import ResponseFormatter
+from plugins_module.plugins_container import PluginsContainer
+from plugins_module.services.configuration_service import (
+    ConfigurationAlreadyExistsError,
+    ConfigurationService,
+    NamespaceNotFoundError,
+)
+
+configuration_router = APIRouter()
+
+
+class CreateConfigurationPayload(BaseModel):
+    namespace: str
+    key: str
+    # Arbitrary JSON document — wavefront never interprets it.
+    value: Any
+    description: Optional[str] = None
+
+
+class UpsertConfigurationPayload(BaseModel):
+    value: Any
+    description: Optional[str] = None
+
+
+@configuration_router.post('/v1/configurations')
+@inject
+async def create_configuration(
+    payload: CreateConfigurationPayload,
+    response_formatter: ResponseFormatter = Depends(
+        Provide[CommonContainer.response_formatter]
+    ),
+    configuration_service: ConfigurationService = Depends(
+        Provide[PluginsContainer.configuration_service]
+    ),
+):
+    try:
+        configuration = await configuration_service.create(
+            namespace=payload.namespace,
+            key=payload.key,
+            value=payload.value,
+            description=payload.description,
+        )
+    except NamespaceNotFoundError as e:
+        return JSONResponse(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            content=response_formatter.buildErrorResponse(str(e)),
+        )
+    except ConfigurationAlreadyExistsError as e:
+        return JSONResponse(
+            status_code=status.HTTP_409_CONFLICT,
+            content=response_formatter.buildErrorResponse(str(e)),
+        )
+
+    return JSONResponse(
+        status_code=status.HTTP_201_CREATED,
+        content=response_formatter.buildSuccessResponse(configuration),
+    )
+
+
+@configuration_router.get('/v1/configurations')
+@inject
+async def list_configurations(
+    namespace: Optional[str] = Query(None),
+    response_formatter: ResponseFormatter = Depends(
+        Provide[CommonContainer.response_formatter]
+    ),
+    configuration_service: ConfigurationService = Depends(
+        Provide[PluginsContainer.configuration_service]
+    ),
+):
+    """List configurations as metadata only — `value` is omitted, since a
+    listing is for discovery and a document can be large."""
+    configurations = await configuration_service.list(namespace=namespace)
+    return JSONResponse(
+        status_code=status.HTTP_200_OK,
+        content=response_formatter.buildSuccessResponse(
+            {'configurations': configurations}
+        ),
+    )
+
+
+@configuration_router.get('/v1/configurations/{namespace}/{key}')
+@inject
+async def get_configuration(
+    namespace: str,
+    key: str,
+    response_formatter: ResponseFormatter = Depends(
+        Provide[CommonContainer.response_formatter]
+    ),
+    configuration_service: ConfigurationService = Depends(
+        Provide[PluginsContainer.configuration_service]
+    ),
+):
+    """Return the configuration document itself.
+
+    This is the read path the `fetch_configuration` function node uses on every
+    workflow run, so the body is the document and nothing else.
+    """
+    value = await configuration_service.get_value(namespace, key)
+    if value is None:
+        return JSONResponse(
+            status_code=status.HTTP_404_NOT_FOUND,
+            content=response_formatter.buildErrorResponse(
+                f"Configuration '{key}' not found in namespace '{namespace}'"
+            ),
+        )
+
+    return JSONResponse(
+        status_code=status.HTTP_200_OK,
+        content=response_formatter.buildSuccessResponse(value),
+    )
+
+
+@configuration_router.put('/v1/configurations/{namespace}/{key}')
+@inject
+async def upsert_configuration(
+    namespace: str,
+    key: str,
+    payload: UpsertConfigurationPayload,
+    response_formatter: ResponseFormatter = Depends(
+        Provide[CommonContainer.response_formatter]
+    ),
+    configuration_service: ConfigurationService = Depends(
+        Provide[PluginsContainer.configuration_service]
+    ),
+):
+    """Replace the configuration's value, creating it if absent.
+
+    The value is replaced wholesale, not merged — a config document is edited as
+    a whole, and a partial-merge rule would make it impossible to remove a field.
+    """
+    try:
+        configuration = await configuration_service.upsert(
+            namespace=namespace,
+            key=key,
+            value=payload.value,
+            description=payload.description,
+        )
+    except NamespaceNotFoundError as e:
+        return JSONResponse(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            content=response_formatter.buildErrorResponse(str(e)),
+        )
+
+    return JSONResponse(
+        status_code=status.HTTP_200_OK,
+        content=response_formatter.buildSuccessResponse(configuration),
+    )
+
+
+@configuration_router.delete('/v1/configurations/{namespace}/{key}')
+@inject
+async def delete_configuration(
+    namespace: str,
+    key: str,
+    response_formatter: ResponseFormatter = Depends(
+        Provide[CommonContainer.response_formatter]
+    ),
+    configuration_service: ConfigurationService = Depends(
+        Provide[PluginsContainer.configuration_service]
+    ),
+):
+    deleted = await configuration_service.delete(namespace, key)
+    if not deleted:
+        return JSONResponse(
+            status_code=status.HTTP_404_NOT_FOUND,
+            content=response_formatter.buildErrorResponse(
+                f"Configuration '{key}' not found in namespace '{namespace}'"
+            ),
+        )
+
+    return JSONResponse(
+        status_code=status.HTTP_200_OK,
+        content=response_formatter.buildSuccessResponse(
+            {'message': f"Configuration '{key}' deleted from namespace '{namespace}'"}
+        ),
+    )

--- a/wavefront/server/modules/plugins_module/plugins_module/plugins_container.py
+++ b/wavefront/server/modules/plugins_module/plugins_module/plugins_container.py
@@ -4,6 +4,7 @@ from db_repo_module.models.datasource import Datasource
 from db_repo_module.models.authenticator import Authenticator
 from db_repo_module.models.message_processors import MessageProcessors
 from db_repo_module.repositories.sql_alchemy_repository import SQLAlchemyRepository
+from plugins_module.services.configuration_service import ConfigurationService
 from plugins_module.services.dynamic_query_service import DynamicQueryService
 from plugins_module.services.message_processor_service import MessageProcessorService
 from flo_cloud.cloud_storage import CloudStorageManager
@@ -17,6 +18,13 @@ class PluginsContainer(containers.DeclarativeContainer):
     cache_manager = providers.Dependency()
 
     dynamic_query_repository = providers.Dependency()
+
+    # Injected from db_repo_container rather than declared here: the namespace
+    # repository already exists there, and the configuration store only needs it
+    # to check that a namespace exists before writing to it.
+    agentic_configuration_repository = providers.Dependency()
+
+    namespace_repository = providers.Dependency()
 
     datasource_repository = providers.Singleton(
         SQLAlchemyRepository[Datasource],
@@ -48,6 +56,13 @@ class PluginsContainer(containers.DeclarativeContainer):
         cloud_storage_manager=cloud_storage_manager,
         dynamic_query_repo=dynamic_query_repository,
         bucket_name=config.floware.asset_storage_bucket,
+    )
+
+    configuration_service = providers.Singleton(
+        ConfigurationService,
+        configuration_repository=agentic_configuration_repository,
+        namespace_repository=namespace_repository,
+        cache_manager=cache_manager,
     )
 
     message_processor_service = providers.Singleton(

--- a/wavefront/server/modules/plugins_module/plugins_module/services/configuration_service.py
+++ b/wavefront/server/modules/plugins_module/plugins_module/services/configuration_service.py
@@ -1,0 +1,172 @@
+"""Service for the namespaced runtime configuration store.
+
+Holds static reference data that deterministic workflow steps need at execution
+time — thresholds, limits, lookup tables. The `value` is an
+arbitrary JSON document that wavefront never interprets.
+"""
+
+import json
+from typing import Any, Dict, List, Optional
+
+from db_repo_module.cache.cache_manager import CacheManager
+from db_repo_module.models.agentic_configuration import AgenticConfiguration
+from db_repo_module.models.namespace import Namespace
+from db_repo_module.repositories.sql_alchemy_repository import SQLAlchemyRepository
+from common_module.log.logger import logger
+
+# Configs are static and read on every workflow run, so they cache well. Writes
+# invalidate explicitly, making the TTL a backstop rather than the mechanism.
+CONFIGURATION_CACHE_TTL_SECONDS = 60 * 60
+
+
+def get_configuration_cache_key(namespace: str, key: str) -> str:
+    return f'configuration:{namespace}:{key}'
+
+
+class NamespaceNotFoundError(Exception):
+    """The namespace a configuration was written to does not exist.
+
+    Raised in preference to letting the foreign key fail, which would surface as
+    an opaque IntegrityError and a 500. The caller almost always mistyped.
+    """
+
+
+class ConfigurationAlreadyExistsError(Exception):
+    """A configuration with this (namespace, key) already exists."""
+
+
+class ConfigurationService:
+    def __init__(
+        self,
+        configuration_repository: SQLAlchemyRepository[AgenticConfiguration],
+        namespace_repository: SQLAlchemyRepository[Namespace],
+        cache_manager: CacheManager,
+    ) -> None:
+        self.configuration_repository = configuration_repository
+        self.namespace_repository = namespace_repository
+        self.cache_manager = cache_manager
+
+    async def _assert_namespace_exists(self, namespace: str) -> None:
+        # Deliberately not get-or-create, the way AgentCrudService does it:
+        # namespace_service lives in agents_module, and importing it here would
+        # give plugins_module a cross-module dependency it does not have.
+        if not await self.namespace_repository.find_one(name=namespace):
+            raise NamespaceNotFoundError(
+                f"Namespace '{namespace}' does not exist. "
+                'Create it first via POST /v1/namespaces.'
+            )
+
+    def _invalidate(self, namespace: str, key: str) -> None:
+        try:
+            self.cache_manager.remove(get_configuration_cache_key(namespace, key))
+        except Exception as e:
+            # A stale cache entry is recoverable (it expires); failing the write
+            # after the row is committed is not.
+            logger.warning(
+                f'Failed to invalidate configuration cache for {namespace}/{key}: {e}'
+            )
+
+    async def get_value(self, namespace: str, key: str) -> Optional[Any]:
+        """Return the config document, or None if there is no such key.
+
+        This is the hot path — every workflow run that uses a config node hits it.
+        """
+        cache_key = get_configuration_cache_key(namespace, key)
+        try:
+            cached = self.cache_manager.get_str(cache_key)
+            if cached is not None:
+                return json.loads(cached)
+        except Exception as e:
+            logger.warning(f'Configuration cache read failed for {cache_key}: {e}')
+
+        configuration = await self.configuration_repository.find_one(
+            namespace=namespace, key=key
+        )
+        if not configuration:
+            return None
+
+        try:
+            self.cache_manager.add(
+                cache_key,
+                json.dumps(configuration.value),
+                expiry=CONFIGURATION_CACHE_TTL_SECONDS,
+            )
+        except Exception as e:
+            logger.warning(f'Configuration cache write failed for {cache_key}: {e}')
+
+        return configuration.value
+
+    async def create(
+        self,
+        namespace: str,
+        key: str,
+        value: Any,
+        description: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        await self._assert_namespace_exists(namespace)
+
+        if await self.configuration_repository.find_one(namespace=namespace, key=key):
+            raise ConfigurationAlreadyExistsError(
+                f"Configuration '{key}' already exists in namespace '{namespace}'. "
+                'Use PUT to replace it.'
+            )
+
+        configuration = await self.configuration_repository.create(
+            namespace=namespace, key=key, value=value, description=description
+        )
+        self._invalidate(namespace, key)
+        return AgenticConfiguration.to_dict(configuration)
+
+    async def upsert(
+        self,
+        namespace: str,
+        key: str,
+        value: Any,
+        description: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        await self._assert_namespace_exists(namespace)
+
+        # The repository's upsert returns None, so the row is read back to
+        # report what was actually stored (including the server-set timestamps).
+        await self.configuration_repository.upsert(
+            filters={'namespace': namespace, 'key': key},
+            value=value,
+            description=description,
+        )
+        self._invalidate(namespace, key)
+
+        configuration = await self.configuration_repository.find_one(
+            namespace=namespace, key=key
+        )
+        return AgenticConfiguration.to_dict(configuration)
+
+    async def delete(self, namespace: str, key: str) -> bool:
+        existing = await self.configuration_repository.find_one(
+            namespace=namespace, key=key
+        )
+        if not existing:
+            return False
+
+        await self.configuration_repository.delete_all(namespace=namespace, key=key)
+        self._invalidate(namespace, key)
+        return True
+
+    async def list(self, namespace: Optional[str] = None) -> List[Dict[str, Any]]:
+        """List configurations as metadata only.
+
+        `value` is omitted: a document can be large, and a listing is for
+        discovery, not for reading the documents.
+        """
+        filters = {'namespace': namespace} if namespace else {}
+        configurations = await self.configuration_repository.find(**filters)
+        return [
+            {
+                'id': str(configuration.id),
+                'namespace': configuration.namespace,
+                'key': configuration.key,
+                'description': configuration.description,
+                'created_at': configuration.created_at.isoformat(),
+                'updated_at': configuration.updated_at.isoformat(),
+            }
+            for configuration in configurations
+        ]

--- a/wavefront/server/modules/plugins_module/plugins_module/services/configuration_service.py
+++ b/wavefront/server/modules/plugins_module/plugins_module/services/configuration_service.py
@@ -6,6 +6,7 @@ arbitrary JSON document that wavefront never interprets.
 """
 
 import json
+import re
 from typing import Any, Dict, List, Optional
 
 from db_repo_module.cache.cache_manager import CacheManager
@@ -17,6 +18,11 @@ from common_module.log.logger import logger
 # Configs are static and read on every workflow run, so they cache well. Writes
 # invalidate explicitly, making the TTL a backstop rather than the mechanism.
 CONFIGURATION_CACHE_TTL_SECONDS = 60 * 60
+
+
+# Keys are a URL path segment, so they are restricted to what addresses cleanly.
+# Same rule as agents_module's validate_agent_workflow_name.
+CONFIGURATION_KEY_PATTERN = re.compile(r'^[a-zA-Z0-9][a-zA-Z0-9_-]*$')
 
 
 def get_configuration_cache_key(namespace: str, key: str) -> str:
@@ -33,6 +39,35 @@ class NamespaceNotFoundError(Exception):
 
 class ConfigurationAlreadyExistsError(Exception):
     """A configuration with this (namespace, key) already exists."""
+
+
+class InvalidConfigurationKeyError(Exception):
+    """The configuration key cannot be addressed in a URL path.
+
+    Keys are a path segment in /v1/configurations/{namespace}/{key}, and the
+    ASGI server percent-decodes the path before routing — so a key containing
+    '/' is unreachable even when the client encodes it as %2F. A POST would
+    create the row and every subsequent GET/PUT/DELETE would 404 on it.
+
+    The pattern matches validate_agent_workflow_name in agents_module, which
+    restricts agent and workflow names for the same reason. It is duplicated
+    rather than imported to avoid giving plugins_module a dependency on
+    agents_module (see _assert_namespace_exists).
+    """
+
+
+class InvalidConfigurationValueError(Exception):
+    """The configuration document is null.
+
+    Refused on write for two reasons. A null document is meaningless — there is
+    nothing for a workflow to read out of it. And it would be unreachable:
+    `value` is jsonb NOT NULL, but SQLAlchemy maps Python None onto JSON `null`
+    rather than SQL NULL (none_as_null is False by default), so the row stores
+    successfully and then reads back as None — indistinguishable from "no such
+    configuration". GET would answer 404 for a row DELETE could still find.
+
+    Rejecting it here is what lets None mean exactly one thing on read.
+    """
 
 
 class ConfigurationService:
@@ -56,6 +91,27 @@ class ConfigurationService:
                 'Create it first via POST /v1/namespaces.'
             )
 
+    @staticmethod
+    def _assert_key_addressable(key: str) -> None:
+        if not CONFIGURATION_KEY_PATTERN.match(key or ''):
+            raise InvalidConfigurationKeyError(
+                f"Configuration key '{key}' is invalid. It must start with a "
+                'letter or number and contain only letters, numbers, hyphens '
+                'and underscores — the key is a URL path segment, so a key '
+                "containing '/' could be created but never read back."
+            )
+
+    @staticmethod
+    def _assert_value_not_null(value: Any) -> None:
+        # Guarded in the service, not just the controller, so the invariant
+        # holds for every caller — it is what makes `get_value` returning None
+        # unambiguously mean "no such configuration".
+        if value is None:
+            raise InvalidConfigurationValueError(
+                'Configuration value cannot be null. Store an object, array or '
+                'scalar; use DELETE to remove a configuration.'
+            )
+
     def _invalidate(self, namespace: str, key: str) -> None:
         try:
             self.cache_manager.remove(get_configuration_cache_key(namespace, key))
@@ -68,6 +124,10 @@ class ConfigurationService:
 
     async def get_value(self, namespace: str, key: str) -> Optional[Any]:
         """Return the config document, or None if there is no such key.
+
+        None is unambiguous here only because writes refuse a null document —
+        see InvalidConfigurationValueError. Every other falsy document (0, "",
+        [], {}) is a real value and is returned as-is.
 
         This is the hot path — every workflow run that uses a config node hits it.
         """
@@ -103,6 +163,8 @@ class ConfigurationService:
         value: Any,
         description: Optional[str] = None,
     ) -> Dict[str, Any]:
+        self._assert_key_addressable(key)
+        self._assert_value_not_null(value)
         await self._assert_namespace_exists(namespace)
 
         if await self.configuration_repository.find_one(namespace=namespace, key=key):
@@ -124,6 +186,8 @@ class ConfigurationService:
         value: Any,
         description: Optional[str] = None,
     ) -> Dict[str, Any]:
+        self._assert_key_addressable(key)
+        self._assert_value_not_null(value)
         await self._assert_namespace_exists(namespace)
 
         # The repository's upsert returns None, so the row is read back to

--- a/wavefront/server/modules/plugins_module/plugins_module/services/dynamic_query_service.py
+++ b/wavefront/server/modules/plugins_module/plugins_module/services/dynamic_query_service.py
@@ -42,7 +42,10 @@ class DynamicQueryService:
 
             # storing to s3bucket
             self.cloud_storage_manager.save_small_file(
-                file_content=file_content, bucket_name=self.bucket_name, key=file_key
+                file_content=file_content,
+                bucket_name=self.bucket_name,
+                key=file_key,
+                disable_cache=True,
             )
 
             # strogin to db

--- a/wavefront/server/modules/plugins_module/plugins_module/services/message_processor_service.py
+++ b/wavefront/server/modules/plugins_module/plugins_module/services/message_processor_service.py
@@ -127,7 +127,10 @@ class MessageProcessorService:
         # Store YAML file in bucket
         yaml_bytes = yaml_content.encode('utf-8')
         self.cloud_storage_manager.save_small_file(
-            file_content=yaml_bytes, bucket_name=self.bucket_name, key=file_path
+            file_content=yaml_bytes,
+            bucket_name=self.bucket_name,
+            key=file_path,
+            disable_cache=True,
         )
         logger.info(f'Stored YAML file at {self.bucket_name}/{file_path}')
 

--- a/wavefront/server/modules/tools_module/pyproject.toml
+++ b/wavefront/server/modules/tools_module/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "Tools module for Flo AI agent system"
 dependencies = [
     "flo-ai==1.1.9",
+    "httpx>=0.27.0,<1.0.0",
     "flo_cloud",
 
     "datasource",

--- a/wavefront/server/modules/tools_module/tools_module/configurations/configuration_api_tools.py
+++ b/wavefront/server/modules/tools_module/tools_module/configurations/configuration_api_tools.py
@@ -1,0 +1,72 @@
+import json
+import os
+from urllib.parse import quote
+
+import httpx
+
+FLOWARE_BASE_URL = os.getenv('FLOWARE_BASE_URL', 'http://localhost:8001').rstrip('/')
+
+
+async def fetch_configuration(namespace: str, key: str) -> str:
+    """Fetch a stored configuration document via wavefront's own REST API
+    (GET /v1/configurations/{namespace}/{key}).
+
+    Configurations hold static reference data a deterministic step needs at
+    execution time — thresholds, limits, lookup tables. Wavefront
+    does not interpret the document; whatever was stored is what comes back.
+
+    One config per node, addressed by namespace and key. To use several, add
+    several nodes: the dependency is then visible in the graph and in the
+    consuming node's `input_filter`, rather than hidden in prefilled params.
+
+        - name: fetch_thresholds
+          function_name: fetch_configuration
+          prefilled_params:
+            namespace: acme-dev
+            key: thresholds
+
+    A message processor cannot fetch this itself — the JS runtime is sandboxed
+    with a short script timeout and no outbound access. It reads the document
+    from `node_outputs`, having selected this node in its `input_filter`:
+
+        const limits = (input.node_outputs || {})['fetch_thresholds'][0];
+
+    Returns the document as a JSON string. Unlike the datasource tools, which
+    return a human-readable confirmation, this node's output is *data for a
+    downstream node*: the function-node adapter parses each input as JSON and
+    only records `node_outputs` for payloads it could parse, so a prose return
+    value would be dropped or would fail the consuming node outright.
+    """
+    url = (
+        f'{FLOWARE_BASE_URL}/floware/v1/configurations/'
+        f'{quote(namespace, safe="")}/{quote(key, safe="")}'
+    )
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.get(url, timeout=30.0)
+        except httpx.RequestError as e:
+            raise Exception(
+                f"Failed to reach configuration API for '{namespace}/{key}': {e}"
+            )
+
+    # Raised rather than returned as a message: a missing config means the
+    # calculation downstream would run on nothing. Failing here names the
+    # namespace and key; returning prose would surface as an unrelated JSON
+    # error in whichever node consumed it.
+    if response.status_code == 404:
+        raise Exception(f"Configuration '{key}' not found in namespace '{namespace}'")
+    if response.status_code != 200:
+        raise Exception(
+            f"Failed to fetch configuration '{namespace}/{key}' "
+            f'({response.status_code}): {response.text}'
+        )
+
+    try:
+        body = response.json()
+    except json.JSONDecodeError:
+        raise Exception(
+            f"Configuration API returned non-JSON for '{namespace}/{key}': "
+            f'{response.text}'
+        )
+
+    return json.dumps(body.get('data'))

--- a/wavefront/server/modules/tools_module/tools_module/registry/function_registry.py
+++ b/wavefront/server/modules/tools_module/tools_module/registry/function_registry.py
@@ -19,6 +19,9 @@ from tools_module.registry.registries.message_processor_registry import (
 from tools_module.registry.registries.api_service_registry import (
     API_SERVICE_REGISTRY,
 )
+from tools_module.registry.registries.configuration_registry import (
+    CONFIGURATION_REGISTRY,
+)
 
 
 # TODO: Import other category registries as they are implemented
@@ -45,6 +48,7 @@ FUNCTION_REGISTRY = _merge_registries(
     UTIL_FUNCTION_REGISTRY,
     MESSAGE_PROCESSOR_REGISTRY,
     API_SERVICE_REGISTRY,
+    CONFIGURATION_REGISTRY,
 )
 
 

--- a/wavefront/server/modules/tools_module/tools_module/registry/registries/configuration_registry.py
+++ b/wavefront/server/modules/tools_module/tools_module/registry/registries/configuration_registry.py
@@ -1,0 +1,13 @@
+"""
+Configuration Tools Registry
+
+Reads from wavefront's namespaced configuration store — static reference data a
+deterministic step needs at execution time, kept out of both the workflow's code
+and the caller's request.
+"""
+
+from tools_module.configurations.configuration_api_tools import fetch_configuration
+
+CONFIGURATION_REGISTRY = {
+    'fetch_configuration': fetch_configuration,
+}

--- a/wavefront/server/uv.lock
+++ b/wavefront/server/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'darwin'",
@@ -2094,6 +2094,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/de/f28ced0a67749cac23fecb02b694f6473f47686dff6afaa211d186e2ef9c/greenlet-3.2.4-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:96378df1de302bc38e99c3a9aa311967b7dc80ced1dcc6f171e99842987882a2", size = 272305, upload-time = "2025-08-07T13:15:41.288Z" },
     { url = "https://files.pythonhosted.org/packages/09/16/2c3792cba130000bf2a31c5272999113f4764fd9d874fb257ff588ac779a/greenlet-3.2.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1ee8fae0519a337f2329cb78bd7a8e128ec0f881073d43f023c7b8d4831d5246", size = 632472, upload-time = "2025-08-07T13:42:55.044Z" },
     { url = "https://files.pythonhosted.org/packages/ae/8f/95d48d7e3d433e6dae5b1682e4292242a53f22df82e6d3dda81b1701a960/greenlet-3.2.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94abf90142c2a18151632371140b3dba4dee031633fe614cb592dbb6c9e17bc3", size = 644646, upload-time = "2025-08-07T13:45:26.523Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/5e/405965351aef8c76b8ef7ad370e5da58d57ef6068df197548b015464001a/greenlet-3.2.4-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:4d1378601b85e2e5171b99be8d2dc85f594c79967599328f95c1dc1a40f1c633", size = 640519, upload-time = "2025-08-07T13:53:13.928Z" },
     { url = "https://files.pythonhosted.org/packages/25/5d/382753b52006ce0218297ec1b628e048c4e64b155379331f25a7316eb749/greenlet-3.2.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0db5594dce18db94f7d1650d7489909b57afde4c580806b8d9203b6e79cdc079", size = 639707, upload-time = "2025-08-07T13:18:27.146Z" },
     { url = "https://files.pythonhosted.org/packages/1f/8e/abdd3f14d735b2929290a018ecf133c901be4874b858dd1c604b9319f064/greenlet-3.2.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2523e5246274f54fdadbce8494458a2ebdcdbc7b802318466ac5606d3cded1f8", size = 587684, upload-time = "2025-08-07T13:18:25.164Z" },
     { url = "https://files.pythonhosted.org/packages/5d/65/deb2a69c3e5996439b0176f6651e0052542bb6c8f8ec2e3fba97c9768805/greenlet-3.2.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1987de92fec508535687fb807a5cea1560f6196285a4cde35c100b8cd632cc52", size = 1116647, upload-time = "2025-08-07T13:42:38.655Z" },
@@ -2104,6 +2105,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/44/69/9b804adb5fd0671f367781560eb5eb586c4d495277c93bde4307b9e28068/greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd", size = 274079, upload-time = "2025-08-07T13:15:45.033Z" },
     { url = "https://files.pythonhosted.org/packages/46/e9/d2a80c99f19a153eff70bc451ab78615583b8dac0754cfb942223d2c1a0d/greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb", size = 640997, upload-time = "2025-08-07T13:42:56.234Z" },
     { url = "https://files.pythonhosted.org/packages/3b/16/035dcfcc48715ccd345f3a93183267167cdd162ad123cd93067d86f27ce4/greenlet-3.2.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f28588772bb5fb869a8eb331374ec06f24a83a9c25bfa1f38b6993afe9c1e968", size = 655185, upload-time = "2025-08-07T13:45:27.624Z" },
+    { url = "https://files.pythonhosted.org/packages/31/da/0386695eef69ffae1ad726881571dfe28b41970173947e7c558d9998de0f/greenlet-3.2.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5c9320971821a7cb77cfab8d956fa8e39cd07ca44b6070db358ceb7f8797c8c9", size = 649926, upload-time = "2025-08-07T13:53:15.251Z" },
     { url = "https://files.pythonhosted.org/packages/68/88/69bf19fd4dc19981928ceacbc5fd4bb6bc2215d53199e367832e98d1d8fe/greenlet-3.2.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c60a6d84229b271d44b70fb6e5fa23781abb5d742af7b808ae3f6efd7c9c60f6", size = 651839, upload-time = "2025-08-07T13:18:30.281Z" },
     { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },
@@ -2114,6 +2116,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/e8/58c7f85958bda41dafea50497cbd59738c5c43dbbea5ee83d651234398f4/greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31", size = 272814, upload-time = "2025-08-07T13:15:50.011Z" },
     { url = "https://files.pythonhosted.org/packages/62/dd/b9f59862e9e257a16e4e610480cfffd29e3fae018a68c2332090b53aac3d/greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945", size = 641073, upload-time = "2025-08-07T13:42:57.23Z" },
     { url = "https://files.pythonhosted.org/packages/f7/0b/bc13f787394920b23073ca3b6c4a7a21396301ed75a655bcb47196b50e6e/greenlet-3.2.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:710638eb93b1fa52823aa91bf75326f9ecdfd5e0466f00789246a5280f4ba0fc", size = 655191, upload-time = "2025-08-07T13:45:29.752Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/d6/6adde57d1345a8d0f14d31e4ab9c23cfe8e2cd39c3baf7674b4b0338d266/greenlet-3.2.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c5111ccdc9c88f423426df3fd1811bfc40ed66264d35aa373420a34377efc98a", size = 649516, upload-time = "2025-08-07T13:53:16.314Z" },
     { url = "https://files.pythonhosted.org/packages/7f/3b/3a3328a788d4a473889a2d403199932be55b1b0060f4ddd96ee7cdfcad10/greenlet-3.2.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d76383238584e9711e20ebe14db6c88ddcedc1829a9ad31a584389463b5aa504", size = 652169, upload-time = "2025-08-07T13:18:32.861Z" },
     { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
     { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
@@ -2124,6 +2127,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/22/5c/85273fd7cc388285632b0498dbbab97596e04b154933dfe0f3e68156c68c/greenlet-3.2.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:49a30d5fda2507ae77be16479bdb62a660fa51b1eb4928b524975b3bde77b3c0", size = 273586, upload-time = "2025-08-07T13:16:08.004Z" },
     { url = "https://files.pythonhosted.org/packages/d1/75/10aeeaa3da9332c2e761e4c50d4c3556c21113ee3f0afa2cf5769946f7a3/greenlet-3.2.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:299fd615cd8fc86267b47597123e3f43ad79c9d8a22bebdce535e53550763e2f", size = 686346, upload-time = "2025-08-07T13:42:59.944Z" },
     { url = "https://files.pythonhosted.org/packages/c0/aa/687d6b12ffb505a4447567d1f3abea23bd20e73a5bed63871178e0831b7a/greenlet-3.2.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c17b6b34111ea72fc5a4e4beec9711d2226285f0386ea83477cbb97c30a3f3a5", size = 699218, upload-time = "2025-08-07T13:45:30.969Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8b/29aae55436521f1d6f8ff4e12fb676f3400de7fcf27fccd1d4d17fd8fecd/greenlet-3.2.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b4a1870c51720687af7fa3e7cda6d08d801dae660f75a76f3845b642b4da6ee1", size = 694659, upload-time = "2025-08-07T13:53:17.759Z" },
     { url = "https://files.pythonhosted.org/packages/92/2e/ea25914b1ebfde93b6fc4ff46d6864564fba59024e928bdc7de475affc25/greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735", size = 695355, upload-time = "2025-08-07T13:18:34.517Z" },
     { url = "https://files.pythonhosted.org/packages/72/60/fc56c62046ec17f6b0d3060564562c64c862948c9d4bc8aa807cf5bd74f4/greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337", size = 657512, upload-time = "2025-08-07T13:18:33.969Z" },
     { url = "https://files.pythonhosted.org/packages/23/6e/74407aed965a4ab6ddd93a7ded3180b730d281c77b765788419484cdfeef/greenlet-3.2.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2917bdf657f5859fbf3386b12d68ede4cf1f04c90c3a6bc1f013dd68a22e2269", size = 1612508, upload-time = "2025-11-04T12:42:23.427Z" },
@@ -2452,9 +2456,9 @@ dependencies = [
     { name = "psycopg2-binary" },
     { name = "python-dotenv" },
     { name = "python-multipart" },
-    { name = "torchvision", version = "0.16.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "torchvision", version = "0.16.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
     { name = "torchvision", version = "0.16.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "torchvision", version = "0.16.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(python_full_version >= '3.12' and sys_platform == 'linux') or (platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "torchvision", version = "0.16.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
     { name = "transformers" },
     { name = "uvicorn" },
 ]
@@ -4760,9 +4764,9 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "textract" },
     { name = "tiktoken" },
-    { name = "torchvision", version = "0.16.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "torchvision", version = "0.16.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
     { name = "torchvision", version = "0.16.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "torchvision", version = "0.16.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(python_full_version >= '3.12' and sys_platform == 'linux') or (platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "torchvision", version = "0.16.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
     { name = "transformers" },
 ]
 
@@ -5578,6 +5582,7 @@ dependencies = [
     { name = "datasource" },
     { name = "flo-ai" },
     { name = "flo-cloud" },
+    { name = "httpx" },
     { name = "knowledge-base-module" },
     { name = "plugins-module" },
 ]
@@ -5594,6 +5599,7 @@ requires-dist = [
     { name = "datasource", editable = "plugins/datasource" },
     { name = "flo-ai", specifier = "==1.1.9" },
     { name = "flo-cloud", editable = "packages/flo_cloud" },
+    { name = "httpx", specifier = ">=0.27.0,<1.0.0" },
     { name = "knowledge-base-module", editable = "modules/knowledge_base_module" },
     { name = "plugins-module", editable = "modules/plugins_module" },
 ]
@@ -5652,13 +5658,16 @@ name = "torchvision"
 version = "0.16.0"
 source = { registry = "https://download.pytorch.org/whl/cpu" }
 resolution-markers = [
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "pillow", marker = "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "requests", marker = "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "torch", marker = "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "numpy", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "pillow", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "requests", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "torch", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/torchvision-0.16.0-cp311-cp311-linux_aarch64.whl", hash = "sha256:9ed5f21e5a56e466667c6f9f6f93dba2a75e29921108bd70043eaf8e9ba0a7cc", upload-time = "2023-10-06T21:47:32Z" },
@@ -5689,19 +5698,16 @@ name = "torchvision"
 version = "0.16.0+cpu"
 source = { registry = "https://download.pytorch.org/whl/cpu" }
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux')",
-    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "(python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
-    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
     "(python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'linux')",
 ]
 dependencies = [
-    { name = "numpy", marker = "(python_full_version >= '3.12' and sys_platform == 'linux') or (platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
-    { name = "pillow", marker = "(python_full_version >= '3.12' and sys_platform == 'linux') or (platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
-    { name = "requests", marker = "(python_full_version >= '3.12' and sys_platform == 'linux') or (platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
-    { name = "torch", marker = "(python_full_version >= '3.12' and sys_platform == 'linux') or (platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "numpy", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "pillow", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "requests", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "torch", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.16.0%2Bcpu-cp311-cp311-linux_x86_64.whl", hash = "sha256:be317c0b0b32d008309a1de6018e77b500d1cf966e158a5db1070da5c0cfea88", upload-time = "2023-10-06T00:36:02Z" },


### PR DESCRIPTION


Deterministic workflow steps need static reference data at execution time — rate tables, thresholds, lookup tables. There was nowhere to put it. The options were all bad: hardcode it in the message processor's JS (a rate change means editing and redeploying code), send it in the caller's request (the whole table on every call), or keep it in the customer's datasource (no generic read tool, and reference data ends up next to business data).

This adds a first-class key/JSON store to wavefront and a function node that reads it, so a processor can be handed exactly the config it needs without knowing where config lives. Nothing about namespace/key/JSON is domain specific, so this stays generic middleware.

Storage
-------
New `agentic_configurations` table: surrogate uuid id, namespace, key, jsonb value, description, timestamps, UNIQUE(namespace, key).

`namespace` is a foreign key to `namespaces.name`, as `agents.namespace` and `workflows.namespace` already are — configs live in the same namespaces as the agents and workflows that read them, so they should reference the same entity rather than drift from it. The concrete win is typo protection: without the constraint a row written under `acmedev` and fetched as `acme-dev` fails at runtime, inside a workflow, with nothing to point at.

Unlike agents, there is no auto-creation. `namespace_service` lives in agents_module and importing it would give plugins_module a cross-module dependency it does not have, so the service checks existence with a plain repository and returns 400 naming the namespace. A raw FK violation would otherwise surface as a 500.

The existing `config` table is deliberately untouched — it is the app's white-labelling store (a single `key='app_config'` row holding the icon and UI settings), with a flat key space and no namespace.

API
---
POST   /v1/configurations                       400 unknown namespace, 409 duplicate
GET    /v1/configurations                       metadata only, no values
GET    /v1/configurations/{namespace}/{key}     the read path the node uses
PUT    /v1/configurations/{namespace}/{key}     upsert; replaces value wholesale
DELETE /v1/configurations/{namespace}/{key}

Rows are addressed by (namespace, key); `id` is a surrogate no route uses, which also keeps `/{namespace}` unambiguous. Reads are cached for an hour with explicit invalidation on write, following the agent-YAML pattern. A cache failure degrades to a database read rather than failing the workflow step that needed the config; a failed invalidation after a committed write is logged, not raised.

The node
--------
`fetch_configuration(namespace, key)` returns the document as a JSON string, not a human-readable confirmation like the datasource tools do. That matters: this node's output is data for a downstream node, and the function-node adapter parses each input as JSON and only records `node_outputs` for payloads it could parse — prose would be dropped or would fail the consuming node outright. A missing config raises rather than returning a message, for the same reason.

No new injection mechanism was needed. The config node's output is selected by the consuming node's `input_filter` and arrives keyed by producer:

    - name: fetch_thresholds
      function_name: fetch_configuration
      prefilled_params: { namespace: acme-dev, key: thresholds }

    - name: apply
      function_name: trigger_message_processor
      input_filter: [some_agent, fetch_thresholds]

    const limits = (input.node_outputs || {})['fetch_thresholds'][0];

A processor cannot fetch config itself — the JS runtime is sandboxed with a short script timeout — so pulling it in as a node input is the only path.

Frontend
--------
Full CRUD under Configurations: list with search and delete, a create dialog, and a JSON editor. Namespace is a dropdown fed from the namespaces API rather than a text field, so the server's unknown-namespace 400 is unreachable. JSON is validated client-side in both the dialog and the editor. The detail page reads `description` from the list, because the detail endpoint returns the bare document (it is the same endpoint the workflow node calls); saving is blocked until that has loaded, since PUT replaces description too.

Also: YAML overwrites now pass disable_cache=True
-------------------------------------------------
Separate concern, found while testing the above. Both message processors and dynamic queries rewrite the SAME bucket key on update, and without the flag the object store kept serving the previous version — the update reported success and the old code went on running, for up to an hour. A message processor edit appeared to do nothing; an edited dynamic query kept returning results from the old SQL.

Agents and workflows already passed this on their update paths, so these two were the outliers rather than a new pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added app-level management for creating, viewing, editing, searching, and deleting namespaced JSON configurations.
  * Added configuration detail pages with validation, descriptions, and save controls.
  * Added configuration retrieval through Floware tools.
* **Bug Fixes**
  * Improved file upload caching after YAML updates.
  * Added more reliable cache removal handling.
* **Navigation**
  * Added Configurations to app navigation and routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->