### PR TITLE
save execution trace to buckets for agents and workflows

### DIFF
--- a/wavefront/server/background_jobs/celery_worker/celery_worker/tasks/agent_task.py
+++ b/wavefront/server/background_jobs/celery_worker/celery_worker/tasks/agent_task.py
@@ -8,6 +8,7 @@ from uuid import UUID
 from common_module.log.logger import logger
 from db_repo_module.models.llm_inference_config import LlmInferenceConfig
 from agents_module.utils.input_processing_utils import process_inference_inputs
+from agents_module.utils.trace_utils import serialize_conversation_trace
 
 from celery_worker.celery_app import app
 from celery_worker.env import MAX_RETRIES, RETRY_DELAY, STREAM_NAME
@@ -71,7 +72,12 @@ def _save_json(cloud_storage, bucket: str, key: str, data: Any) -> None:
     )
 
 
-def _build_history(payload: Dict, result: Any, exec_time: float) -> Dict:
+def _build_history(
+    payload: Dict,
+    result: Any,
+    exec_time: float,
+    trace: Optional[List[Dict[str, Any]]] = None,
+) -> Dict:
     return {
         'execution_id': payload['execution_id'],
         'entity_type': payload['entity_type'],
@@ -80,6 +86,7 @@ def _build_history(payload: Dict, result: Any, exec_time: float) -> Dict:
         'variables': payload.get('variables') or {},
         'output': result,
         'execution_time_seconds': round(exec_time, 3),
+        'trace': trace or [],  # full per-node/turn memory, in execution order
     }
 
 
@@ -118,6 +125,11 @@ async def _run(task, payload: Dict) -> None:
         )
 
         final_result = result[-1].content if isinstance(result, list) else result
+        trace = (
+            serialize_conversation_trace('agent', result)
+            if isinstance(result, list)
+            else []
+        )
 
         output_key = f"{payload['output_prefix']}output.json"
         history_key = f"{payload['output_prefix']}history.json"
@@ -136,7 +148,7 @@ async def _run(task, payload: Dict) -> None:
             services.cloud_storage,
             bucket,
             history_key,
-            _build_history(payload, final_result, exec_time),
+            _build_history(payload, final_result, exec_time, trace),
         )
 
         # Signal completed — floware consumer updates DB

--- a/wavefront/server/background_jobs/celery_worker/celery_worker/tasks/workflow_task.py
+++ b/wavefront/server/background_jobs/celery_worker/celery_worker/tasks/workflow_task.py
@@ -32,7 +32,11 @@ async def _run(task, payload: Dict) -> None:
     try:
         inputs = _reconstruct_inputs(payload, services.cloud_storage)
 
-        result, exec_time = await services.workflow_inference.perform_inference_v2(
+        (
+            result,
+            exec_time,
+            trace,
+        ) = await services.workflow_inference.perform_inference_v2(
             workflow_data={
                 'id': payload['entity_id'],
                 'name': payload['workflow_name'],
@@ -65,7 +69,7 @@ async def _run(task, payload: Dict) -> None:
             services.cloud_storage,
             bucket,
             history_key,
-            _build_history(payload, result, exec_time),
+            _build_history(payload, result, exec_time, trace),
         )
 
         # Signal completed — floware consumer updates DB

--- a/wavefront/server/background_jobs/workflow_job/workflow_job/workflow_processor.py
+++ b/wavefront/server/background_jobs/workflow_job/workflow_job/workflow_processor.py
@@ -78,6 +78,7 @@ class WorkflowMessageProcessor(MessageProcessor[ProcessingResult[Dict[str, Any]]
         (
             result,
             execution_time,
+            _trace,
         ) = await self.workflow_inference_service.perform_inference_v2(
             workflow_data=workflow_data,
             variables=variables,

--- a/wavefront/server/modules/agents_module/agents_module/controllers/workflow_controller.py
+++ b/wavefront/server/modules/agents_module/agents_module/controllers/workflow_controller.py
@@ -367,7 +367,7 @@ async def workflow_inference_v2(
                     event_data = event_queue.get_nowait()
                     yield f'data: {json.dumps(event_data)}\n\n'
 
-                result, execution_time = await inference_task
+                result, execution_time, _trace = await inference_task
 
                 output_event = {
                     'event_type': 'output',
@@ -410,7 +410,11 @@ async def workflow_inference_v2(
 
     else:
         # Non-streaming mode - normal JSON response
-        result, execution_time = await workflow_inference_service.perform_inference_v2(
+        (
+            result,
+            execution_time,
+            _trace,
+        ) = await workflow_inference_service.perform_inference_v2(
             workflow_data=workflow_data,
             variables=with_execution_variables(request_body.variables, execution_id),
             inputs=resolved_inputs

--- a/wavefront/server/modules/agents_module/agents_module/services/workflow_inference_service.py
+++ b/wavefront/server/modules/agents_module/agents_module/services/workflow_inference_service.py
@@ -25,6 +25,7 @@ from agents_module.utils.workflow_reference_utils import (
 )
 from flo_ai.arium import AriumEventType, AriumEvent, MessageMemoryItem
 from agents_module.services.agent_crud_service import AgentCrudService
+from agents_module.utils.trace_utils import serialize_memory_trace
 from tools_module.registry.tool_loader import ToolLoader
 from tools_module.registry.function_node_registry import FUNCTION_NODE_REGISTRY
 
@@ -297,7 +298,7 @@ class WorkflowInferenceService:
         output_json_enabled: bool = True,
         event_callback: Optional[Callable[[AriumEvent], None]] = None,
         events_filter: Optional[List[AriumEventType]] = None,
-    ) -> tuple[str, float]:
+    ) -> tuple[str, float, List[Dict[str, Any]]]:
         """
         Run workflow inference with provided variables
 
@@ -311,7 +312,9 @@ class WorkflowInferenceService:
             events_filter: Optional list of event types to filter
 
         Returns:
-            tuple: (result, execution_time)
+            tuple: (result, execution_time, trace) — trace is the full
+                per-node memory (every node's output plus the initial
+                inputs), serialized for history.json.
         """
         logger.info(
             f'Running inference for workflow {workflow_name} with variables: {list(variables.keys())}'
@@ -333,6 +336,7 @@ class WorkflowInferenceService:
         )
 
         result_str = str(result_list[-1].result.content)
+        trace = serialize_memory_trace(result_list)
 
         # Conditionally extract JSON based on output_json_enabled flag
         if output_json_enabled:
@@ -345,7 +349,7 @@ class WorkflowInferenceService:
             f'Successfully completed inference for workflow {workflow_name} in {execution_time:.2f} seconds'
         )
 
-        return result, execution_time
+        return result, execution_time, trace
 
     async def perform_inference(
         self,
@@ -386,7 +390,7 @@ class WorkflowInferenceService:
         )
 
         # Run inference with optional event streaming
-        result, execution_time = await self.run_workflow_inference(
+        result, execution_time, _trace = await self.run_workflow_inference(
             workflow,
             inputs,
             variables,
@@ -408,7 +412,7 @@ class WorkflowInferenceService:
         events_filter: Optional[List[AriumEventType]] = None,
         access_token: Optional[str] = None,
         app_key: Optional[str] = None,
-    ) -> tuple[str, float]:
+    ) -> tuple[str, float, List[Dict[str, Any]]]:
         """
         Complete inference workflow (v2): use pre-fetched workflow data, run inference
 
@@ -428,7 +432,9 @@ class WorkflowInferenceService:
             events_filter: Optional list of event types to filter
 
         Returns:
-            tuple: (result, execution_time)
+            tuple: (result, execution_time, trace) — trace is the full
+                per-node memory (every node's output plus the initial
+                inputs), serialized for history.json.
         """
         # Extract details from pre-fetched workflow data
         namespace = workflow_data['namespace']
@@ -453,7 +459,7 @@ class WorkflowInferenceService:
         )
 
         # Run inference with optional event streaming
-        result, execution_time = await self.run_workflow_inference(
+        result, execution_time, trace = await self.run_workflow_inference(
             workflow,
             inputs,
             variables,
@@ -463,4 +469,4 @@ class WorkflowInferenceService:
             events_filter,
         )
 
-        return result, execution_time
+        return result, execution_time, trace

--- a/wavefront/server/modules/agents_module/agents_module/utils/trace_utils.py
+++ b/wavefront/server/modules/agents_module/agents_module/utils/trace_utils.py
@@ -1,0 +1,72 @@
+"""
+Serialize flo-ai execution memory (Arium's per-node MessageMemory, or a
+single agent's conversation_history) into the JSON-safe `trace` recorded in
+an execution's history.json — one entry per node/turn, in execution order,
+so an eval agent can see which node/agent produced which output.
+
+Media content (images/documents) is recorded as a reference (mime type +
+storage url) only — never the raw base64/bytes payload.
+"""
+
+from typing import Any, Dict, List
+
+from flo_ai import (
+    BaseMessage,
+    TextMessageContent,
+    ImageMessageContent,
+    DocumentMessageContent,
+)
+from flo_ai.arium import MessageMemoryItem
+
+
+def _serialize_content(content: Any) -> Any:
+    if isinstance(content, TextMessageContent):
+        return content.text
+    if isinstance(content, (ImageMessageContent, DocumentMessageContent)):
+        return {
+            'type': content.type,
+            'mime_type': content.mime_type,
+            'reference': content.url,
+        }
+    return content
+
+
+def _serialize_message(message: BaseMessage) -> Dict[str, Any]:
+    return {
+        'role': getattr(message, 'role', None),
+        'name': getattr(message, 'name', None),
+        'content': _serialize_content(getattr(message, 'content', message)),
+        'metadata': getattr(message, 'metadata', None) or {},
+    }
+
+
+def serialize_memory_trace(
+    memory_items: List[MessageMemoryItem],
+) -> List[Dict[str, Any]]:
+    """Serialize an Arium workflow's full MessageMemory (every node's output,
+    plus the initial 'input' entries) in execution order."""
+    return [
+        {
+            'node': item.node,
+            'occurrence': item.occurrence,
+            **_serialize_message(item.result),
+        }
+        for item in memory_items
+    ]
+
+
+def serialize_conversation_trace(
+    agent_node: str, conversation: List[BaseMessage]
+) -> List[Dict[str, Any]]:
+    """Serialize a single agent's full conversation_history into the same
+    trace shape as serialize_memory_trace. Messages the agent produced
+    (assistant/function replies) are tagged with `agent_node`; messages it
+    received (system/user) are tagged 'input', mirroring Arium's
+    producer/input distinction.
+    """
+    trace = []
+    for occurrence, message in enumerate(conversation, start=1):
+        entry = _serialize_message(message)
+        node = 'input' if entry['role'] in ('system', 'user') else agent_node
+        trace.append({'node': node, 'occurrence': occurrence, **entry})
+    return trace


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added conversation traces to agent inference history for easier inspection of inputs and responses.
  * Added workflow execution traces containing per-step inputs and outputs.
  * Preserved text, image, and document details, including content types and references, in serialized traces.

* **Improvements**
  * Traces are supported across streaming and non-streaming workflow inference.
  * Existing inference results and execution-time reporting remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->