### PR TITLE
removed authorization header from azure openai service call

### DIFF
--- a/wavefront/server/modules/llm_inference_config_module/llm_inference_config_module/services/inference_proxy_service.py
+++ b/wavefront/server/modules/llm_inference_config_module/llm_inference_config_module/services/inference_proxy_service.py
@@ -117,6 +117,7 @@ class InferenceProxyService:
     def _prepare_azure_openai_auth(self, headers: Dict[str, str], api_key: str) -> None:
         """Prepare Azure OpenAI authentication headers."""
         headers['api-key'] = api_key
+        del headers['authorization']
 
     def _prepare_ollama_auth(self, headers: Dict[str, str], api_key: str) -> None:
         """Prepare Ollama authentication headers (typically no auth required)."""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Azure OpenAI authentication by removing the original authorization header after adding the API key, ensuring requests use the intended authentication method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->