### PR TITLE
fix: support path params in HMAC_AUTH_ROUTES matching

### DIFF
--- a/wavefront/server/modules/user_management_module/user_management_module/authorization/require_auth.py
+++ b/wavefront/server/modules/user_management_module/user_management_module/authorization/require_auth.py
@@ -52,7 +52,11 @@ optional_auth_apis = [
     '/floware/v1/triggers/{trigger_id}/{agentic_id}/invoke',
 ]
 
-hmac_routes = os.getenv('HMAC_AUTH_ROUTES', '').split(',')
+hmac_routes = [
+    route.strip()
+    for route in os.getenv('HMAC_AUTH_ROUTES', '').split(',')
+    if route.strip()
+]
 
 floware_jwt_audience = os.getenv('FLOWARE_JWT_AUDIENCE', '')
 
@@ -108,6 +112,14 @@ def matches_dynamic_route(path: str, route_pattern: str) -> bool:
     regex_pattern = f'^{regex_pattern}$'
 
     return bool(re.match(regex_pattern, path))
+
+
+def matches_any_route(path: str, route_patterns: list[str]) -> bool:
+    """Check if a path matches any route in the list (supports {param} placeholders)."""
+    return any(
+        path == pattern if '{' not in pattern else matches_dynamic_route(path, pattern)
+        for pattern in route_patterns
+    )
 
 
 async def validate_service_auth(
@@ -217,9 +229,8 @@ async def validate_hmac_signature(
             )
             return False
 
-        if request.headers.get('X-Rootflo-Nonce'):
-            nonce = request.headers.get('X-Rootflo-Nonce')
-        else:
+        nonce = request.headers.get(RootfloHeaders.NONCE)
+        if not nonce:
             body = await request.body()
 
             # Parse JSON body to extract nonce
@@ -357,7 +368,9 @@ class RequireAuthMiddleware(BaseHTTPMiddleware):
 
             authorization = request.headers.get('Authorization')
             # Check if this endpoint requires HMAC validation (skip JWT validation then)
-            if request.url.path in required_hmac_apis and not authorization:
+            if not authorization and matches_any_route(
+                request.url.path, required_hmac_apis
+            ):
                 if not await validate_hmac_signature(request, auth_secrets_repository):
                     request_id = getattr(
                         request.state, 'request_id', get_current_request_id()
@@ -400,12 +413,7 @@ class RequireAuthMiddleware(BaseHTTPMiddleware):
                     token = authorization.split(' ')[1]
 
                 # Skip authentication for optional APIs (supports {param} placeholders)
-                if any(
-                    request.url.path == pattern
-                    if '{' not in pattern
-                    else matches_dynamic_route(request.url.path, pattern)
-                    for pattern in optional_auth_apis
-                ):
+                if matches_any_route(request.url.path, optional_auth_apis):
                     return await call_next(request)
 
                 # For non-production environments: Check passthrough authentication globally

--- a/wavefront/server/modules/user_management_module/user_management_module/constants/auth.py
+++ b/wavefront/server/modules/user_management_module/user_management_module/constants/auth.py
@@ -5,6 +5,7 @@ class RootfloHeaders:
     CLIENT_KEY = 'X-Rootflo-Key'
     SIGNATURE = 'X-Rootflo-Signature'
     TIMESTAMP = 'X-Rootflo-Timestamp'
+    NONCE = 'X-Rootflo-Nonce'
     PASSTHROUGH = 'X-Passthrough'
 
 


### PR DESCRIPTION
HMAC routes were matched with an exact string comparison against required_hmac_apis, so any pattern containing a path placeholder never matched a real request. With HMAC_AUTH_ROUTES set to '/some_route/{param_id}', a request to
/some_route/abc skipped the HMAC branch entirely
and fell through to the JWT flow, failing with 401 "Token missing in request".

- Extract matches_any_route() from the optional_auth_apis check and use it for the HMAC route check as well, so both support {param} placeholders.
- Strip whitespace and drop empty entries when parsing HMAC_AUTH_ROUTES, so an unset var no longer yields [''] and ', ' separators work.
- Check for a missing Authorization header before route matching so authenticated requests short-circuit before the regex pass.
- Add RootfloHeaders.NONCE and replace the hardcoded 'X-Rootflo-Nonce' literals, collapsing a duplicated header lookup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved HMAC route matching for exact and parameterized paths.
  - Ignored blank entries and surrounding whitespace in configured HMAC routes.
  - Improved nonce detection by checking the authentication header before the request body.
  - Applied consistent route handling to required HMAC and optional-auth endpoints.
- **Authentication**
  - Added support for the `X-Rootflo-Nonce` authentication header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->