### PR TITLE
fix: reactivate failed scheduled jobs

### DIFF
--- a/wavefront/client/src/pages/apps/[appId]/scheduled-jobs/index.tsx
+++ b/wavefront/client/src/pages/apps/[appId]/scheduled-jobs/index.tsx
@@ -104,9 +104,13 @@ const ScheduledJobsPage: React.FC = () => {
   const handlePauseResume = async (job: ScheduledJob) => {
     setActionJobId(job.id);
     try {
-      if (job.status === 'paused') {
+      if (job.status === 'paused' || job.status === 'failed') {
         await floConsoleService.scheduledJobService.resumeScheduledJob(job.id);
-        notifySuccess('Scheduled job resumed');
+        notifySuccess(
+          job.status === 'failed'
+            ? 'Scheduled job resumed; it will run on the next scheduler poll'
+            : 'Scheduled job resumed'
+        );
       } else {
         await floConsoleService.scheduledJobService.pauseScheduledJob(job.id);
         notifySuccess('Scheduled job paused');
@@ -230,7 +234,7 @@ const ScheduledJobsPage: React.FC = () => {
               {filteredJobs.map((job) => {
                 const payload = job.payload || {};
                 const datasourceId = getDatasourceIdFromPayload(payload);
-                const canPauseResume = job.status === 'active' || job.status === 'paused';
+                const canPauseResume = job.status === 'active' || job.status === 'paused' || job.status === 'failed';
                 return (
                   <TableRow key={job.id}>
                     <TableCell>
@@ -265,7 +269,7 @@ const ScheduledJobsPage: React.FC = () => {
                             disabled={actionJobId === job.id}
                             onClick={() => void handlePauseResume(job)}
                           >
-                            {job.status === 'paused' ? 'Resume' : 'Pause'}
+                            {job.status === 'paused' || job.status === 'failed' ? 'Resume' : 'Pause'}
                           </Button>
                         ) : null}
                         <Button variant="outline" size="sm" onClick={() => handleEdit(job)}>

--- a/wavefront/server/apps/floware/floware/services/scheduled_job_service.py
+++ b/wavefront/server/apps/floware/floware/services/scheduled_job_service.py
@@ -236,6 +236,18 @@ class ScheduledJobService:
         if status is not None:
             updates['status'] = status
 
+        reactivating_failed = (
+            job.status == 'failed'
+            and updates
+            and (status is None or status == 'active')
+        )
+        if reactivating_failed or status == 'active':
+            updates['status'] = 'active'
+            updates['retry_count'] = 0
+            updates['last_error'] = None
+        if reactivating_failed:
+            updates['next_run_at'] = datetime.now(timezone.utc)
+
         if updates:
             return await self.scheduled_job_repository.find_one_and_update(
                 filters={'id': job_id}, refresh=True, **updates
@@ -251,11 +263,22 @@ class ScheduledJobService:
         job = await self.scheduled_job_repository.find_one(id=job_id)
         if not job:
             return None
+        updates: dict = {
+            'status': 'active',
+            'retry_count': 0,
+            'last_error': None,
+        }
+        if job.status == 'failed':
+            # Run on the next poller tick rather than waiting until the next cron.
+            updates['next_run_at'] = datetime.now(timezone.utc)
+        else:
+            updates['next_run_at'] = self._compute_next_run_at(
+                job.cron_expr, job.timezone
+            )
         return await self.scheduled_job_repository.find_one_and_update(
             filters={'id': job_id},
             refresh=True,
-            status='active',
-            next_run_at=self._compute_next_run_at(job.cron_expr, job.timezone),
+            **updates,
         )
 
     async def delete_job(self, job_id: str) -> bool:

--- a/wavefront/server/apps/floware/floware/services/scheduled_job_service.py
+++ b/wavefront/server/apps/floware/floware/services/scheduled_job_service.py
@@ -235,18 +235,10 @@ class ScheduledJobService:
             updates['max_retries'] = max_retries
         if status is not None:
             updates['status'] = status
-
-        reactivating_failed = (
-            job.status == 'failed'
-            and updates
-            and (status is None or status == 'active')
-        )
-        if reactivating_failed or status == 'active':
-            updates['status'] = 'active'
-            updates['retry_count'] = 0
-            updates['last_error'] = None
-        if reactivating_failed:
-            updates['next_run_at'] = datetime.now(timezone.utc)
+            # Reactivate a failed job.
+            if status == 'active' and job.status == 'failed':
+                updates['retry_count'] = 0
+                updates['last_error'] = None
 
         if updates:
             return await self.scheduled_job_repository.find_one_and_update(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Failed scheduled jobs can now be resumed from the scheduled jobs page.
  * Resuming a failed job clears its failure state and schedules it for its next eligible run.
  * Failed jobs now display a Resume action alongside active and paused jobs.
  * Added a distinct notification when a failed job is resumed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->