### PR TITLE
feat: audit trail for datasource row mutations

### DIFF
--- a/wavefront/server/apps/floware/floware/server.py
+++ b/wavefront/server/apps/floware/floware/server.py
@@ -56,6 +56,9 @@ from floware.services.scheduler_manager import SchedulerManager
 from plugins_module.plugins_container import PluginsContainer
 from plugins_module.controllers.configuration_controller import configuration_router
 from plugins_module.controllers.datasource_controller import datasource_router
+from plugins_module.controllers.datasource_audit_controller import (
+    datasource_audit_router,
+)
 from plugins_module.controllers.authenticator_controller import authenticator_router
 from floware.controllers.config_controller import config_router
 from floware.controllers.scheduled_job_controller import scheduled_job_router
@@ -154,6 +157,7 @@ plugins_container = PluginsContainer(
     cache_manager=db_repo_container.cache_manager,
     namespace_repository=db_repo_container.namespace_repository,
     agentic_configuration_repository=db_repo_container.agentic_configuration_repository,
+    datasource_audit_log_repository=db_repo_container.datasource_audit_log_repository,
 )
 
 product_analysis_container = ProductAnalysisContainer()
@@ -431,6 +435,7 @@ app.include_router(rag_retrieval_router, prefix='/floware')
 app.include_router(gold_router, prefix='/floware')
 app.include_router(subscription_controller, prefix='/floware')
 app.include_router(datasource_router, prefix='/floware')
+app.include_router(datasource_audit_router, prefix='/floware')
 app.include_router(hmac_router, prefix='/floware')
 app.include_router(authenticator_router, prefix='/floware')
 app.include_router(config_router, prefix='/floware')

--- a/wavefront/server/modules/db_repo_module/db_repo_module/alembic/env.py
+++ b/wavefront/server/modules/db_repo_module/db_repo_module/alembic/env.py
@@ -46,6 +46,7 @@ from db_repo_module.models.workflow import Workflow
 from db_repo_module.models.workflow_version import WorkflowVersion
 from db_repo_module.models.workflow_pipeline import WorkflowPipeline
 from db_repo_module.models.workflow_runs import WorkflowRuns
+from db_repo_module.models.datasource_audit_log import DatasourceAuditLog
 from dotenv import load_dotenv
 from sqlalchemy import engine_from_config
 from sqlalchemy import pool
@@ -102,6 +103,7 @@ models = [
     WorkflowVersion,
     WorkflowPipeline,
     WorkflowRuns,
+    DatasourceAuditLog,
 ]
 target_metadata = Base.metadata
 

--- a/wavefront/server/modules/db_repo_module/db_repo_module/alembic/versions/2026_08_20_1200-d4f1a7c3e2b8_create_datasource_audit_logs_table.py
+++ b/wavefront/server/modules/db_repo_module/db_repo_module/alembic/versions/2026_08_20_1200-d4f1a7c3e2b8_create_datasource_audit_logs_table.py
@@ -1,0 +1,109 @@
+"""create datasource_audit_logs table
+
+Revision ID: d4f1a7c3e2b8
+Revises: c7e2a1b4d9f3
+Create Date: 2026-08-20 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = 'd4f1a7c3e2b8'
+down_revision: Union[str, None] = 'c7e2a1b4d9f3'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'datasource_audit_logs',
+        sa.Column('id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('batch_id', postgresql.UUID(as_uuid=True), nullable=False),
+        # Intentionally no ForeignKeyConstraint to datasource.id: that row is
+        # hard-deleted, and the audit trail has to outlive it.
+        sa.Column('datasource_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            'datasource_type',
+            sa.String(length=32),
+            nullable=False,
+            comment='possible values: postgres, gcp_bigquery, aws_redshift, mssql',
+        ),
+        sa.Column('table_name', sa.String(length=512), nullable=False),
+        sa.Column(
+            'operation',
+            sa.String(length=16),
+            nullable=False,
+            comment='possible values: insert, update, delete',
+        ),
+        sa.Column('filter', sa.String(length=512), nullable=True),
+        sa.Column(
+            'filter_params', postgresql.JSONB(astext_type=sa.Text()), nullable=True
+        ),
+        sa.Column('changes', postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column('meta', postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column('rows_affected', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('user_id', sa.String(length=255), nullable=False),
+        sa.Column('role_id', sa.String(length=255), nullable=False),
+        sa.Column('request_id', sa.String(length=64), nullable=True),
+        sa.Column(
+            'created_at', sa.DateTime(), nullable=False, server_default=sa.func.now()
+        ),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(
+        op.f('ix_datasource_audit_logs_id'), 'datasource_audit_logs', ['id']
+    )
+    op.create_index(
+        op.f('ix_datasource_audit_logs_batch_id'), 'datasource_audit_logs', ['batch_id']
+    )
+    # (selective_col, created_at) so one scan serves both the equality filter
+    # and the ORDER BY created_at DESC every listing uses.
+    op.create_index(
+        'ix_datasource_audit_logs_datasource_created',
+        'datasource_audit_logs',
+        ['datasource_id', 'created_at'],
+    )
+    op.create_index(
+        'ix_datasource_audit_logs_table_created',
+        'datasource_audit_logs',
+        ['table_name', 'created_at'],
+    )
+    op.create_index(
+        'ix_datasource_audit_logs_user_created',
+        'datasource_audit_logs',
+        ['user_id', 'created_at'],
+    )
+    # Plain btree: exact match and left-anchored prefix only. Substring search
+    # would need a GIN trigram index (pg_trgm), deferred until it is a real
+    # access pattern.
+    op.create_index(
+        'ix_datasource_audit_logs_filter', 'datasource_audit_logs', ['filter']
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        'ix_datasource_audit_logs_filter', table_name='datasource_audit_logs'
+    )
+    op.drop_index(
+        'ix_datasource_audit_logs_user_created', table_name='datasource_audit_logs'
+    )
+    op.drop_index(
+        'ix_datasource_audit_logs_table_created', table_name='datasource_audit_logs'
+    )
+    op.drop_index(
+        'ix_datasource_audit_logs_datasource_created',
+        table_name='datasource_audit_logs',
+    )
+    op.drop_index(
+        op.f('ix_datasource_audit_logs_batch_id'), table_name='datasource_audit_logs'
+    )
+    op.drop_index(
+        op.f('ix_datasource_audit_logs_id'), table_name='datasource_audit_logs'
+    )
+    op.drop_table('datasource_audit_logs')

--- a/wavefront/server/modules/db_repo_module/db_repo_module/alembic/versions/2026_08_20_1200-d4f1a7c3e2b8_create_datasource_audit_logs_table.py
+++ b/wavefront/server/modules/db_repo_module/db_repo_module/alembic/versions/2026_08_20_1200-d4f1a7c3e2b8_create_datasource_audit_logs_table.py
@@ -1,7 +1,7 @@
 """create datasource_audit_logs table
 
 Revision ID: d4f1a7c3e2b8
-Revises: c7e2a1b4d9f3
+Revises: 314534601d35
 Create Date: 2026-08-20 12:00:00.000000
 
 """
@@ -14,7 +14,7 @@ from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision: str = 'd4f1a7c3e2b8'
-down_revision: Union[str, None] = 'c7e2a1b4d9f3'
+down_revision: Union[str, None] = '314534601d35'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
@@ -87,9 +87,7 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_index(
-        'ix_datasource_audit_logs_filter', table_name='datasource_audit_logs'
-    )
+    op.drop_index('ix_datasource_audit_logs_filter', table_name='datasource_audit_logs')
     op.drop_index(
         'ix_datasource_audit_logs_user_created', table_name='datasource_audit_logs'
     )

--- a/wavefront/server/modules/db_repo_module/db_repo_module/db_repo_container.py
+++ b/wavefront/server/modules/db_repo_module/db_repo_module/db_repo_container.py
@@ -19,6 +19,7 @@ from db_repo_module.models.user_role import UserRole
 from db_repo_module.models.product_analytics import ProductAnalytics
 from db_repo_module.models.session import Session
 from db_repo_module.models.agentic_configuration import AgenticConfiguration
+from db_repo_module.models.datasource_audit_log import DatasourceAuditLog
 from db_repo_module.models.config import Config
 from db_repo_module.models.dynamic_query_yaml import DynamicQueryYaml
 from db_repo_module.models.model_schema import ModelSchema
@@ -241,6 +242,11 @@ class DatabaseModuleContainer(containers.DeclarativeContainer):
     datasource_repository = providers.Singleton(
         SQLAlchemyRepository[Datasource],
         model=Datasource,
+        db_client=db_client,
+    )
+    datasource_audit_log_repository = providers.Singleton(
+        SQLAlchemyRepository[DatasourceAuditLog],
+        model=DatasourceAuditLog,
         db_client=db_client,
     )
     scheduled_job_repository = providers.Singleton(

--- a/wavefront/server/modules/db_repo_module/db_repo_module/models/datasource_audit_log.py
+++ b/wavefront/server/modules/db_repo_module/db_repo_module/models/datasource_audit_log.py
@@ -1,0 +1,161 @@
+"""Audit trail for data-plane row mutations made through the datasource API.
+
+One row per (request, table). A single-table endpoint writes one row; the
+multi-table endpoints write one per table, all sharing a ``batch_id`` — those
+tables moved in one transaction, and the trail has to be able to say so.
+
+Written best-effort and out-of-band against a *different* database from the one
+that was mutated, so the two can never share a transaction. A missing row means
+"the audit write lost", not "the mutation did not happen"; the reverse cannot
+occur, because the audit is only ever written after the mutation commits.
+"""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Index, Integer, String, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from ..database.base import Base
+
+
+class DatasourceAuditLog(Base):
+    __tablename__ = 'datasource_audit_logs'
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, index=True
+    )
+
+    # Groups the rows written by one HTTP request. Always set, even for the
+    # single-table endpoints, so a consumer never has to special-case them.
+    batch_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), nullable=False, index=True
+    )
+
+    # No ForeignKey to datasource.id on purpose: delete_datasource hard-deletes
+    # that row, and a FK would either cascade this trail away or block the
+    # delete. An audit record has to outlive the thing it audits.
+    datasource_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+
+    # Denormalized for the same reason there is no FK: once the datasource is
+    # gone, this row is the only surviving record of what type it was.
+    datasource_type: Mapped[str] = mapped_column(
+        String(length=32),
+        nullable=False,
+        comment='possible values: postgres, gcp_bigquery, aws_redshift, mssql',
+    )
+
+    # Free-form, exactly as the caller supplied it (possibly 'schema.table').
+    # Deliberately not an allowlist: the mutation endpoints do not run
+    # check_is_valid_resource, so this table is the only record of a write to a
+    # non-allowlisted table and must be able to name one.
+    table_name: Mapped[str] = mapped_column(String(length=512), nullable=False)
+
+    operation: Mapped[str] = mapped_column(
+        String(length=16),
+        nullable=False,
+        comment='possible values: insert, update, delete',
+    )
+
+    # The OData filter as the caller wrote it, not the compiled SQL predicate:
+    # the compiled form is an implementation detail of the parser, while the
+    # OData string is what the caller can be held to. Null for inserts.
+    #
+    # 512 rather than something roomier because this column is indexed: a btree
+    # entry caps at ~2704 bytes, and 512 chars of worst-case 4-byte UTF-8 is
+    # 2048. The service truncates anything longer and flags it in `meta` — an
+    # over-length filter must cost fidelity, never the whole audit row.
+    filter: Mapped[str] = mapped_column(String(length=512), nullable=True)
+
+    # The predicate reduced to its column -> value pairs, as the OData parser
+    # produced them. Exists purely to make "which mutations targeted this column
+    # with this value" a lookup rather than a substring scan over `filter`.
+    #
+    # Derived and deliberately redundant, never a replacement for `filter`: the
+    # parser drops the comparison operator and the boolean structure, so
+    # `x eq 1` and `x gt 1` reduce to the same pairs, as do `a $and b` and
+    # `a $or b`. Only the string says what actually ran.
+    filter_params: Mapped[dict] = mapped_column(JSONB, nullable=True)
+
+    # {'snapshot': 'submitted'|'after'|'deleted', 'rows': [...]}. The bulky part,
+    # and the part that carries customer data. Nullable so that "capture was not
+    # available" stays distinguishable from "the mutation touched no rows".
+    changes: Mapped[dict] = mapped_column(JSONB, nullable=True)
+
+    # Small request context — requested patch, batch position, whether the call
+    # spanned several tables. Never row data: that separation is what lets the
+    # list endpoint return `meta` while omitting `changes`.
+    meta: Mapped[dict] = mapped_column(JSONB, nullable=True)
+
+    # cursor.rowcount — what the statement really touched, which is not
+    # necessarily how many rows ended up in `changes`.
+    rows_affected: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+
+    # String, never UUID: the service-auth paths put literal non-UUID identities
+    # on the session ('service', 'hmac-service', 'passthrough',
+    # 'floconsole-service'), and a uuid column would reject every one of them.
+    user_id: Mapped[str] = mapped_column(String(length=255), nullable=False)
+    role_id: Mapped[str] = mapped_column(String(length=255), nullable=False)
+
+    # X-Flo-Request-ID, for correlating against the application logs.
+    request_id: Mapped[str] = mapped_column(String(length=64), nullable=True)
+
+    # Set by the service at mutation time rather than left to func.now(): the
+    # write happens on a background task that may run well after the mutation
+    # committed, and a trail timestamped by write time cannot be ordered against
+    # anything. The server default is a backstop only.
+    created_at: Mapped[datetime] = mapped_column(nullable=False, default=func.now())
+
+    # Composites are (selective_col, created_at) so one scan serves both the
+    # equality filter and the ORDER BY created_at DESC that every listing uses —
+    # btree scans backwards, so an ASC index serves a DESC sort.
+    #
+    # `operation` and `datasource_type` are filterable but not indexed: 3-4
+    # distinct values each, so Postgres would not choose a btree over a
+    # created_at scan and the write cost would buy nothing.
+    __table_args__ = (
+        Index(
+            'ix_datasource_audit_logs_datasource_created',
+            'datasource_id',
+            'created_at',
+        ),
+        Index('ix_datasource_audit_logs_table_created', 'table_name', 'created_at'),
+        Index('ix_datasource_audit_logs_user_created', 'user_id', 'created_at'),
+        # Plain btree: serves exact match and left-anchored prefix. A
+        # "which mutations mention Q-1" substring search needs a GIN trigram
+        # index (pg_trgm) instead, which is why the read API exposes no
+        # contains filter today.
+        Index('ix_datasource_audit_logs_filter', 'filter'),
+    )
+
+    @staticmethod
+    def get_table_name():
+        return DatasourceAuditLog.__tablename__
+
+    def to_dict(self, include_changes: bool = False):
+        """Serialize for the read API.
+
+        ``changes`` is opt-in: it is unbounded and carries customer row data, so
+        a listing that returned it would be both enormous and needlessly
+        wide-reaching. The detail route asks for it explicitly.
+        """
+        result = {
+            'id': str(self.id),
+            'batch_id': str(self.batch_id),
+            'datasource_id': str(self.datasource_id),
+            'datasource_type': self.datasource_type,
+            'table_name': self.table_name,
+            'operation': self.operation,
+            'filter': self.filter,
+            'filter_params': self.filter_params,
+            'meta': self.meta,
+            'rows_affected': self.rows_affected,
+            'user_id': self.user_id,
+            'role_id': self.role_id,
+            'request_id': self.request_id,
+            'created_at': self.created_at.isoformat() if self.created_at else None,
+        }
+        if include_changes:
+            result['changes'] = self.changes
+        return result

--- a/wavefront/server/modules/plugins_module/plugins_module/controllers/datasource_audit_controller.py
+++ b/wavefront/server/modules/plugins_module/plugins_module/controllers/datasource_audit_controller.py
@@ -1,0 +1,271 @@
+"""Admin-only read API over the datasource row-mutation audit trail.
+
+Kept in its own router rather than added to ``datasource_router``: these routes
+are a read-only administrative surface with nothing in common with the data
+plane, and the path is deliberately a sibling of ``/v1/datasources`` rather than
+a child. A child path like ``/v1/datasources/audit-logs`` would be matched by the
+existing ``GET /v1/datasources/{datasource_id}`` — FastAPI resolves in
+declaration order — which is the same hazard the comment above
+``update_rows_json_multi`` in datasource_controller.py documents.
+"""
+
+from typing import Any, Dict, Optional, Tuple
+from datetime import datetime
+
+from dependency_injector.wiring import Provide, inject
+from fastapi import Depends, Query, Request, status
+from fastapi.responses import JSONResponse
+from fastapi.routing import APIRouter
+
+from common_module.common_container import CommonContainer
+from common_module.response_formatter import ResponseFormatter
+from common_module.utils.serializer import serialize_values
+from common_module.utils.validators import is_valid_uuid
+from db_repo_module.models.datasource_audit_log import DatasourceAuditLog
+from db_repo_module.repositories.sql_alchemy_repository import SQLAlchemyRepository
+from plugins_module.plugins_container import PluginsContainer
+from user_management_module.utils.user_utils import check_is_admin, get_current_user
+
+datasource_audit_router = APIRouter()
+
+VALID_OPERATIONS = ('insert', 'update', 'delete')
+
+# Query params starting with this address a column of the *mutated* row, looked
+# up in filter_params. The prefix is not decoration: the audited schemas are the
+# caller's, so a mutated table may well have a column sharing a name with one of
+# this table's own (`user_id`, `created_at`, `id`), and a bare `?user_id=` could
+# mean either the actor or the targeted row's value.
+FILTER_PARAM_PREFIX = 'param.'
+
+
+def _extract_filter_params(request: Request) -> Dict[str, str]:
+    """Pull `param.<column>=<value>` pairs out of the query string.
+
+    Read off the raw query string because the column names are the caller's
+    data, not a fixed set FastAPI could declare as arguments.
+    """
+    return {
+        key[len(FILTER_PARAM_PREFIX) :]: value
+        for key, value in request.query_params.items()
+        if key.startswith(FILTER_PARAM_PREFIX) and key != FILTER_PARAM_PREFIX
+    }
+
+# Every column, `changes` included. It is what a listing is usually for — a UI
+# rendering "what changed" would otherwise fetch the list and then one detail
+# request per row.
+#
+# Size is bounded rather than avoided: an update stores a diff of only the
+# columns it set, and the audit service caps every record at 20 rows / 256 KiB.
+# Deletes are the heavy case, since those keep the whole row; a page of them is
+# the reason `limit` is capped.
+LIST_COLUMNS = (
+    'id, batch_id, datasource_id, datasource_type, table_name, operation, '
+    '"filter", filter_params, changes, meta, rows_affected, user_id, role_id, '
+    'request_id, created_at'
+)
+
+
+def _build_where(filters: Dict[str, Any]) -> Tuple[str, Dict[str, Any]]:
+    """Build the shared WHERE fragment and its bound parameters.
+
+    One builder feeds both the page query and the COUNT, so the two can never
+    disagree about what is being counted.
+    """
+    predicates = []
+    params: Dict[str, Any] = {}
+
+    for column in (
+        'datasource_id',
+        'batch_id',
+        'table_name',
+        'operation',
+        'user_id',
+        'request_id',
+    ):
+        value = filters.get(column)
+        if value is not None:
+            predicates.append(f'{column} = :{column}')
+            params[column] = value
+
+    if filters.get('filter') is not None:
+        predicates.append('"filter" = :filter_exact')
+        params['filter_exact'] = filters['filter']
+
+    # Matched against the parsed predicate rather than the filter text, so it
+    # does not care whether the caller wrote this column first or third, and
+    # cannot false-positive on a value that happens to appear elsewhere in the
+    # string. Several pairs AND together.
+    for index, (column, value) in enumerate(
+        sorted((filters.get('filter_params') or {}).items())
+    ):
+        # Both sides bound, never interpolated: the column name arrives from the
+        # query string, and jsonb ->> takes it as a value rather than as SQL, so
+        # there is nothing to escape.
+        predicates.append(f'filter_params ->> :fp_key_{index} = :fp_val_{index}')
+        params[f'fp_key_{index}'] = column
+        params[f'fp_val_{index}'] = value
+
+    if filters.get('from_date') is not None:
+        predicates.append('created_at >= :from_date')
+        params['from_date'] = filters['from_date']
+
+    if filters.get('to_date') is not None:
+        predicates.append('created_at <= :to_date')
+        params['to_date'] = filters['to_date']
+
+    where = ' AND '.join(predicates) if predicates else 'TRUE'
+    return where, params
+
+
+@datasource_audit_router.get('/v1/datasource-audit-logs')
+@inject
+async def list_datasource_audit_logs(
+    request: Request,
+    datasource_id: Optional[str] = None,
+    batch_id: Optional[str] = None,
+    table_name: Optional[str] = None,
+    operation: Optional[str] = None,
+    user_id: Optional[str] = None,
+    request_id: Optional[str] = None,
+    filter: Optional[str] = None,
+    from_date: Optional[datetime] = None,
+    to_date: Optional[datetime] = None,
+    offset: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=200),
+    response_formatter: ResponseFormatter = Depends(
+        Provide[CommonContainer.response_formatter]
+    ),
+    audit_log_repository: SQLAlchemyRepository[DatasourceAuditLog] = Depends(
+        Provide[PluginsContainer.datasource_audit_log_repository]
+    ),
+):
+    """List audit records, newest first, each with its full `changes` document.
+
+    Columns of the *mutated* row are addressed with a `param.` prefix and AND
+    together: `?param.<column>=<value>`. Those match the parsed predicate, so a
+    mutation is found only if the caller named that column in its filter — a row
+    targeted by one of its columns is not findable by another, even though the
+    row carries both.
+    """
+    role_id, _, _ = get_current_user(request)
+    if not await check_is_admin(role_id):
+        return JSONResponse(
+            status_code=status.HTTP_403_FORBIDDEN,
+            content=response_formatter.buildErrorResponse('Admin access required'),
+        )
+
+    # Checked before the query rather than after: these columns are uuid, so a
+    # malformed value raises InvalidTextRepresentation and surfaces as a 500
+    # with a SQL traceback instead of the 400 it should have been.
+    for name, value in (('datasource_id', datasource_id), ('batch_id', batch_id)):
+        if value is not None and not is_valid_uuid(value):
+            return JSONResponse(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                content=response_formatter.buildErrorResponse(
+                    f'Invalid {name}: {value}'
+                ),
+            )
+
+    if operation is not None and operation not in VALID_OPERATIONS:
+        return JSONResponse(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            content=response_formatter.buildErrorResponse(
+                f'Invalid operation: {operation}. '
+                f'Expected one of: {", ".join(VALID_OPERATIONS)}'
+            ),
+        )
+
+    where, params = _build_where(
+        {
+            'datasource_id': datasource_id,
+            'batch_id': batch_id,
+            'table_name': table_name,
+            'operation': operation,
+            # Never coerced to a UUID: service identities are literals like
+            # 'hmac-service'.
+            'user_id': user_id,
+            'request_id': request_id,
+            'filter': filter,
+            'filter_params': _extract_filter_params(request),
+            'from_date': from_date,
+            'to_date': to_date,
+        }
+    )
+
+    total_rows = await audit_log_repository.execute_query(
+        f'SELECT COUNT(*) AS total FROM datasource_audit_logs WHERE {where}',
+        params,
+    )
+    total = total_rows[0]['total'] if total_rows else 0
+
+    logs = await audit_log_repository.execute_query(
+        f'SELECT {LIST_COLUMNS} FROM datasource_audit_logs WHERE {where} '
+        # id breaks ties: created_at is not unique under concurrent writes, and
+        # an unstable sort makes offset pagination skip and repeat rows.
+        'ORDER BY created_at DESC, id DESC LIMIT :limit OFFSET :offset',
+        {**params, 'limit': limit, 'offset': offset},
+    )
+
+    return JSONResponse(
+        status_code=status.HTTP_200_OK,
+        content=response_formatter.buildSuccessResponse(
+            {
+                # execute_query returns raw datetime/UUID objects.
+                'logs': [serialize_values(log) for log in logs],
+                'count': len(logs),
+                'total': total,
+                'offset': offset,
+                'limit': limit,
+            }
+        ),
+    )
+
+
+@datasource_audit_router.get('/v1/datasource-audit-logs/{audit_log_id}')
+@inject
+async def get_datasource_audit_log(
+    request: Request,
+    audit_log_id: str,
+    response_formatter: ResponseFormatter = Depends(
+        Provide[CommonContainer.response_formatter]
+    ),
+    audit_log_repository: SQLAlchemyRepository[DatasourceAuditLog] = Depends(
+        Provide[PluginsContainer.datasource_audit_log_repository]
+    ),
+):
+    """One audit record by id.
+
+    Returns the same fields the listing does; it exists for fetching a single
+    record you already have the id of, typically from a `batch_id` or
+    `request_id` you followed from somewhere else.
+    """
+    role_id, _, _ = get_current_user(request)
+    if not await check_is_admin(role_id):
+        return JSONResponse(
+            status_code=status.HTTP_403_FORBIDDEN,
+            content=response_formatter.buildErrorResponse('Admin access required'),
+        )
+
+    if not is_valid_uuid(audit_log_id):
+        return JSONResponse(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            content=response_formatter.buildErrorResponse(
+                f'Invalid audit log id: {audit_log_id}'
+            ),
+        )
+
+    audit_log = await audit_log_repository.find_one(id=audit_log_id)
+    if not audit_log:
+        return JSONResponse(
+            status_code=status.HTTP_404_NOT_FOUND,
+            content=response_formatter.buildErrorResponse(
+                f'Audit log not found: {audit_log_id}'
+            ),
+        )
+
+    return JSONResponse(
+        status_code=status.HTTP_200_OK,
+        content=response_formatter.buildSuccessResponse(
+            {'log': audit_log.to_dict(include_changes=True)}
+        ),
+    )

--- a/wavefront/server/modules/plugins_module/plugins_module/controllers/datasource_audit_controller.py
+++ b/wavefront/server/modules/plugins_module/plugins_module/controllers/datasource_audit_controller.py
@@ -1,4 +1,4 @@
-"""Admin-only read API over the datasource row-mutation audit trail.
+"""Read API over the datasource row-mutation audit trail, admin-only by default.
 
 Kept in its own router rather than added to ``datasource_router``: these routes
 are a read-only administrative surface with nothing in common with the data
@@ -18,6 +18,10 @@ from fastapi.responses import JSONResponse
 from fastapi.routing import APIRouter
 
 from common_module.common_container import CommonContainer
+from common_module.feature.feature_flag import (
+    ALLOW_NON_ADMIN_ALL_DATA_ACCESS_FLAG,
+    is_feature_enabled,
+)
 from common_module.response_formatter import ResponseFormatter
 from common_module.utils.serializer import serialize_values
 from common_module.utils.validators import is_valid_uuid
@@ -49,6 +53,22 @@ def _extract_filter_params(request: Request) -> Dict[str, str]:
         for key, value in request.query_params.items()
         if key.startswith(FILTER_PARAM_PREFIX) and key != FILTER_PARAM_PREFIX
     }
+
+
+async def _can_read_audit_logs(request: Request) -> bool:
+    """Read access to the audit trail: admin only, by default.
+
+    ALLOW_NON_ADMIN_ALL_DATA_ACCESS_FLAG lifts the same gate off the datasource
+    read paths, and the trail is a record of those rows, so it follows them —
+    a deployment that lets every authenticated user read the data has no reason
+    to hide what was done to it.
+    """
+    if is_feature_enabled(ALLOW_NON_ADMIN_ALL_DATA_ACCESS_FLAG):
+        return True
+
+    role_id, _, _ = get_current_user(request)
+    return await check_is_admin(role_id)
+
 
 # Every column, `changes` included. It is what a listing is usually for — a UI
 # rendering "what changed" would otherwise fetch the list and then one detail
@@ -147,8 +167,7 @@ async def list_datasource_audit_logs(
     targeted by one of its columns is not findable by another, even though the
     row carries both.
     """
-    role_id, _, _ = get_current_user(request)
-    if not await check_is_admin(role_id):
+    if not await _can_read_audit_logs(request):
         return JSONResponse(
             status_code=status.HTTP_403_FORBIDDEN,
             content=response_formatter.buildErrorResponse('Admin access required'),
@@ -239,8 +258,7 @@ async def get_datasource_audit_log(
     record you already have the id of, typically from a `batch_id` or
     `request_id` you followed from somewhere else.
     """
-    role_id, _, _ = get_current_user(request)
-    if not await check_is_admin(role_id):
+    if not await _can_read_audit_logs(request):
         return JSONResponse(
             status_code=status.HTTP_403_FORBIDDEN,
             content=response_formatter.buildErrorResponse('Admin access required'),

--- a/wavefront/server/modules/plugins_module/plugins_module/controllers/datasource_controller.py
+++ b/wavefront/server/modules/plugins_module/plugins_module/controllers/datasource_controller.py
@@ -42,6 +42,10 @@ from plugins_module.utils.helper import (
     UpdateRowsJsonMultiPayload,
 )
 from flo_cloud.postgres import NoRowsMatchedError
+from plugins_module.services.datasource_audit_service import (
+    AuditEntry,
+    DatasourceAuditService,
+)
 from plugins_module.plugins_container import PluginsContainer
 from user_management_module.user_container import UserContainer
 from user_management_module.services.user_service import UserService
@@ -516,6 +520,63 @@ async def query_datasource(
     )
 
 
+def _insert_entries(prepared: list[dict], payload_inserts) -> list[AuditEntry]:
+    """One audit entry per table for the multi-table insert path.
+
+    Inserts have no RETURNING: what gets recorded is what was submitted, which
+    is what `snapshot: 'submitted'` says. Server defaults, triggers and
+    generated columns are therefore not reflected.
+
+    ``meta.multi_table`` records that the call spanned several tables, not that
+    it was transactional — every mutation through these endpoints is, since even
+    a single-table multi-row insert is one executemany in one transaction.
+    """
+    return [
+        AuditEntry(
+            table_name=spec['table_name'],
+            snapshot='submitted',
+            rows=spec['data'],
+            rows_affected=len(spec['data']),
+            meta={
+                'multi_table': True,
+                'batch_index': index,
+                'batch_size': len(prepared),
+                'single_row': payload_inserts[index].single_row,
+            },
+        )
+        for index, spec in enumerate(prepared)
+    ]
+
+
+def _update_entries(results, payload) -> list[AuditEntry]:
+    """One audit entry per table for the multi-table update path.
+
+    ``results`` and ``payload.updates`` are index-aligned: the client builds one
+    RowMutationResult per entry, in order.
+    """
+    return [
+        AuditEntry(
+            table_name=result.table_name,
+            snapshot='after',
+            rows=result.rows,
+            before_rows=result.before_rows,
+            key_columns=result.key_columns,
+            rows_affected=result.rows_affected,
+            truncated=result.truncated,
+            filter=update.filter,
+            filter_params=result.filter_params,
+            meta={
+                'multi_table': True,
+                'require_all_matched': payload.require_all_matched,
+                'batch_index': index,
+                'batch_size': len(results),
+                'patch': update.data,
+            },
+        )
+        for index, (result, update) in enumerate(zip(results, payload.updates))
+    ]
+
+
 @datasource_router.post('/v1/datasources/{datasource_id}/resources/insert')
 @inject
 async def insert_rows_json_multi(
@@ -524,6 +585,9 @@ async def insert_rows_json_multi(
     insert_rows_json_multi_payload: InsertRowsJsonMultiPayload,
     response_formatter: ResponseFormatter = Depends(
         Provide[CommonContainer.response_formatter]
+    ),
+    datasource_audit_service: DatasourceAuditService = Depends(
+        Provide[PluginsContainer.datasource_audit_service]
     ),
 ):
     """Insert rows into multiple tables of one datasource atomically.
@@ -558,6 +622,14 @@ async def insert_rows_json_multi(
             content=response_formatter.buildErrorResponse(str(e)),
         )
 
+    datasource_audit_service.record_from_request(
+        request,
+        datasource_id=datasource_id,
+        datasource_type=datasource_type,
+        operation='insert',
+        entries=_insert_entries(prepared, insert_rows_json_multi_payload.inserts),
+    )
+
     total_rows = sum(len(p['data']) for p in prepared)
     return JSONResponse(
         status_code=status.HTTP_200_OK,
@@ -582,6 +654,9 @@ async def insert_rows_json(
     response_formatter: ResponseFormatter = Depends(
         Provide[CommonContainer.response_formatter]
     ),
+    datasource_audit_service: DatasourceAuditService = Depends(
+        Provide[PluginsContainer.datasource_audit_service]
+    ),
 ):
     datasource_type, datasource_config = await get_datasource_config(datasource_id)
     if not datasource_config:
@@ -600,6 +675,26 @@ async def insert_rows_json(
     await asyncio.to_thread(
         datasource_plugin.insert_rows_json, resource_id, rows_with_created_at
     )
+
+    # The only mutation path that runs for every datasource type, not just
+    # Postgres — it needs no RETURNING, because the rows submitted are already
+    # in hand.
+    datasource_audit_service.record_from_request(
+        request,
+        datasource_id=datasource_id,
+        datasource_type=datasource_type,
+        operation='insert',
+        entries=[
+            AuditEntry(
+                table_name=resource_id,
+                snapshot='submitted',
+                rows=rows_with_created_at,
+                rows_affected=len(rows_with_created_at),
+                meta={'multi_table': False},
+            )
+        ],
+    )
+
     return JSONResponse(
         status_code=status.HTTP_200_OK,
         content=response_formatter.buildSuccessResponse(
@@ -623,6 +718,9 @@ async def update_rows_json_multi(
     update_rows_json_multi_payload: UpdateRowsJsonMultiPayload,
     response_formatter: ResponseFormatter = Depends(
         Provide[CommonContainer.response_formatter]
+    ),
+    datasource_audit_service: DatasourceAuditService = Depends(
+        Provide[PluginsContainer.datasource_audit_service]
     ),
 ):
     """Update rows across multiple tables of one datasource atomically.
@@ -673,6 +771,8 @@ async def update_rows_json_multi(
             datasource_plugin.update_rows_json_multi,
             [update.model_dump() for update in update_rows_json_multi_payload.updates],
             update_rows_json_multi_payload.require_all_matched,
+            capture=True,
+            capture_limit=datasource_audit_service.capture_limit,
         )
     except NotImplementedError as e:
         return JSONResponse(
@@ -693,7 +793,23 @@ async def update_rows_json_multi(
             content=response_formatter.buildErrorResponse(str(e)),
         )
 
-    total_rows = sum(result['updated_rows'] for result in results)
+    datasource_audit_service.record_from_request(
+        request,
+        datasource_id=datasource_id,
+        datasource_type=datasource_type,
+        operation='update',
+        entries=_update_entries(results, update_rows_json_multi_payload),
+    )
+
+    total_rows = sum(result.rows_affected for result in results)
+    # Rebuilt field by field rather than serialized wholesale: the client
+    # contract is exactly {table_name, updated_rows}, and handing the richer
+    # result object straight to JSONResponse is how captured row data would end
+    # up in an API response.
+    client_results = [
+        {'table_name': result.table_name, 'updated_rows': result.rows_affected}
+        for result in results
+    ]
     return JSONResponse(
         status_code=status.HTTP_200_OK,
         content=response_formatter.buildSuccessResponse(
@@ -703,7 +819,7 @@ async def update_rows_json_multi(
                     f'{len(results)} table(s) successfully'
                 ),
                 'updated_rows': total_rows,
-                'results': results,
+                'results': client_results,
             }
         ),
     )
@@ -718,6 +834,9 @@ async def update_rows_json(
     update_rows_json_payload: UpdateRowsJsonPayload,
     response_formatter: ResponseFormatter = Depends(
         Provide[CommonContainer.response_formatter]
+    ),
+    datasource_audit_service: DatasourceAuditService = Depends(
+        Provide[PluginsContainer.datasource_audit_service]
     ),
 ):
     """Update the rows of one table matching an OData filter.
@@ -756,11 +875,13 @@ async def update_rows_json(
     datasource_plugin = DatasourcePlugin(datasource_type, datasource_config)
 
     try:
-        updated_rows = await asyncio.to_thread(
+        result = await asyncio.to_thread(
             datasource_plugin.update_rows_json,
             resource_id,
             update_rows_json_payload.data,
             update_rows_json_payload.filter,
+            capture=True,
+            capture_limit=datasource_audit_service.capture_limit,
         )
     except NotImplementedError as e:
         return JSONResponse(
@@ -774,6 +895,28 @@ async def update_rows_json(
             content=response_formatter.buildErrorResponse(str(e)),
         )
 
+    datasource_audit_service.record_from_request(
+        request,
+        datasource_id=datasource_id,
+        datasource_type=datasource_type,
+        operation='update',
+        entries=[
+            AuditEntry(
+                table_name=resource_id,
+                snapshot='after',
+                rows=result.rows,
+                before_rows=result.before_rows,
+                key_columns=result.key_columns,
+                rows_affected=result.rows_affected,
+                truncated=result.truncated,
+                filter=update_rows_json_payload.filter,
+                filter_params=result.filter_params,
+                meta={'multi_table': False, 'patch': update_rows_json_payload.data},
+            )
+        ],
+    )
+
+    updated_rows = result.rows_affected
     return JSONResponse(
         status_code=status.HTTP_200_OK,
         content=response_formatter.buildSuccessResponse(
@@ -794,6 +937,9 @@ async def delete_rows_json(
     delete_rows_json_payload: DeleteRowsJsonPayload,
     response_formatter: ResponseFormatter = Depends(
         Provide[CommonContainer.response_formatter]
+    ),
+    datasource_audit_service: DatasourceAuditService = Depends(
+        Provide[PluginsContainer.datasource_audit_service]
     ),
 ):
     """Delete the rows of one table matching an OData filter.
@@ -832,10 +978,12 @@ async def delete_rows_json(
     datasource_plugin = DatasourcePlugin(datasource_type, datasource_config)
 
     try:
-        deleted_rows = await asyncio.to_thread(
+        result = await asyncio.to_thread(
             datasource_plugin.delete_rows_json,
             resource_id,
             delete_rows_json_payload.filter,
+            capture=True,
+            capture_limit=datasource_audit_service.capture_limit,
         )
     except NotImplementedError as e:
         return JSONResponse(
@@ -849,6 +997,28 @@ async def delete_rows_json(
             content=response_formatter.buildErrorResponse(str(e)),
         )
 
+    # The captured rows are the only remaining record of what was destroyed —
+    # after the commit above they exist nowhere else.
+    datasource_audit_service.record_from_request(
+        request,
+        datasource_id=datasource_id,
+        datasource_type=datasource_type,
+        operation='delete',
+        entries=[
+            AuditEntry(
+                table_name=resource_id,
+                snapshot='deleted',
+                rows=result.rows,
+                rows_affected=result.rows_affected,
+                truncated=result.truncated,
+                filter=delete_rows_json_payload.filter,
+                filter_params=result.filter_params,
+                meta={'multi_table': False},
+            )
+        ],
+    )
+
+    deleted_rows = result.rows_affected
     return JSONResponse(
         status_code=status.HTTP_200_OK,
         content=response_formatter.buildSuccessResponse(

--- a/wavefront/server/modules/plugins_module/plugins_module/plugins_container.py
+++ b/wavefront/server/modules/plugins_module/plugins_module/plugins_container.py
@@ -7,6 +7,7 @@ from db_repo_module.repositories.sql_alchemy_repository import SQLAlchemyReposit
 from plugins_module.services.configuration_service import ConfigurationService
 from plugins_module.services.dynamic_query_service import DynamicQueryService
 from plugins_module.services.message_processor_service import MessageProcessorService
+from plugins_module.services.datasource_audit_service import DatasourceAuditService
 from flo_cloud.cloud_storage import CloudStorageManager
 
 
@@ -25,6 +26,10 @@ class PluginsContainer(containers.DeclarativeContainer):
     agentic_configuration_repository = providers.Dependency()
 
     namespace_repository = providers.Dependency()
+
+    # Same reasoning: declared once in db_repo_container alongside every other
+    # repository, and handed in here rather than re-declared.
+    datasource_audit_log_repository = providers.Dependency()
 
     datasource_repository = providers.Singleton(
         SQLAlchemyRepository[Datasource],
@@ -63,6 +68,11 @@ class PluginsContainer(containers.DeclarativeContainer):
         configuration_repository=agentic_configuration_repository,
         namespace_repository=namespace_repository,
         cache_manager=cache_manager,
+    )
+
+    datasource_audit_service = providers.Singleton(
+        DatasourceAuditService,
+        audit_log_repository=datasource_audit_log_repository,
     )
 
     message_processor_service = providers.Singleton(

--- a/wavefront/server/modules/plugins_module/plugins_module/services/datasource_audit_service.py
+++ b/wavefront/server/modules/plugins_module/plugins_module/services/datasource_audit_service.py
@@ -1,0 +1,452 @@
+"""Records data-plane row mutations made through the datasource API.
+
+The mutation lands in the *customer's* datasource (psycopg2, synchronous, reached
+via ``asyncio.to_thread``); the audit row lands in the *application* database
+(SQLAlchemy async). Two servers, two drivers, two transactions — they cannot be
+made atomic, so this service is best-effort by contract:
+
+* it is only ever called after the mutation has already committed, so an audit
+  row can never claim a change that did not happen;
+* it never raises, so a failure here cannot turn a successful 200 into a 500;
+* consequently "no audit row" means "the audit write lost", not "no mutation".
+
+Writes happen on a background task so the caller's response is not held up by a
+second database round trip.
+"""
+
+import asyncio
+import json
+import math
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from common_module.log.logger import logger
+from common_module.middleware.request_id_middleware import get_current_request_id
+from common_module.utils.serializer import serialize_values
+from db_repo_module.models.datasource_audit_log import DatasourceAuditLog
+from db_repo_module.repositories.sql_alchemy_repository import SQLAlchemyRepository
+from user_management_module.utils.user_utils import get_current_user
+
+# Bounds on how much of a mutation is stored. Either can be set to None to lift
+# that limit entirely; `rows_affected` is taken from cursor.rowcount and is never
+# capped, so the true scale of a change survives whatever gets dropped here.
+#
+# The two limits catch different shapes, and the audited schemas are the
+# caller's, so both are reachable. A delete matching thousands of narrow join
+# rows is bounded by the row count; a handful of rows from a wide table, where a
+# single row of jsonb columns runs to several KB, is bounded by bytes. Neither
+# alone is enough.
+AUDIT_MAX_ROWS: Optional[int] = 20
+AUDIT_MAX_PAYLOAD_BYTES: Optional[int] = 256 * 1024  # 256 KiB of serialized rows
+
+# Matches the `filter` column width. The column is indexed, and a btree entry
+# caps at ~2704 bytes, so the column cannot simply be widened without dropping
+# that index.
+AUDIT_FILTER_MAX_CHARS = 512
+
+# Held module-level: asyncio.create_task keeps only a weak reference to the task,
+# so one with no other referent can be garbage collected mid-await and vanish
+# silently. Keeping a strong reference until it finishes is the documented fix.
+_pending_audit_tasks: set = set()
+
+
+@dataclass(frozen=True)
+class AuditEntry:
+    """One table's worth of an audited mutation.
+
+    ``rows`` distinguishes three states that must not be conflated: a list of
+    rows, ``[]`` (captured, and the statement matched nothing), and ``None``
+    (no capture was available — a datasource type with no RETURNING path).
+    """
+
+    table_name: str
+    snapshot: str  # submitted | after | deleted
+    rows: Optional[List[Dict[str, Any]]]
+    rows_affected: int
+    # The same rows as they were before an update. Present only on the update
+    # paths, and None when the capture was unavailable or failed — in which case
+    # the record degrades to an after-only snapshot rather than losing anything.
+    before_rows: Optional[List[Dict[str, Any]]] = None
+    # The table's primary key, present in both row sets so they can be paired.
+    key_columns: Optional[List[str]] = None
+    filter: Optional[str] = None  # OData, as the caller wrote it
+    # The predicate's column -> value pairs. A derived search key, not a
+    # substitute for `filter`: the parser drops operators and boolean structure.
+    filter_params: Optional[Dict[str, Any]] = None
+    meta: Dict[str, Any] = field(default_factory=dict)
+    # Set when the datasource client already stopped short of fetching every
+    # affected row. Without it a client-side cap is invisible here: the rows that
+    # arrive are exactly at the limit rather than over it, so nothing downstream
+    # would notice that more existed.
+    truncated: bool = False
+
+
+@dataclass(frozen=True)
+class AuditActor:
+    """Who made the change.
+
+    All strings, never UUIDs: the service-auth paths put literals like
+    'hmac-service' on the session, and typing these as UUID would fail the insert
+    for exactly the traffic that is hardest to attribute.
+    """
+
+    user_id: str
+    role_id: str
+    request_id: Optional[str]
+
+
+def _log_audit_task_result(task: asyncio.Task) -> None:
+    """Surface an exception from a fire-and-forget task.
+
+    Nothing awaits these, so without this the traceback appears only as a
+    "task exception was never retrieved" warning at interpreter shutdown, if at
+    all.
+    """
+    if task.cancelled():
+        return
+    exception = task.exception()
+    if exception is not None:
+        logger.error(f'Datasource audit write failed: {exception}')
+
+
+class DatasourceAuditService:
+    def __init__(
+        self,
+        audit_log_repository: SQLAlchemyRepository[DatasourceAuditLog],
+        max_rows: Optional[int] = AUDIT_MAX_ROWS,
+        max_payload_bytes: Optional[int] = AUDIT_MAX_PAYLOAD_BYTES,
+    ) -> None:
+        self.audit_log_repository = audit_log_repository
+        self.max_rows = max_rows
+        self.max_payload_bytes = max_payload_bytes
+
+    @property
+    def capture_limit(self) -> Optional[int]:
+        """How many rows the datasource client should be asked to return.
+
+        Controllers read this rather than importing a constant, so the component
+        that owns the storage decides how much of it to ask for. ``None`` means
+        no limit.
+        """
+        return self.max_rows
+
+    def record_from_request(
+        self,
+        request,
+        *,
+        datasource_id: str,
+        datasource_type: str,
+        operation: str,
+        entries: Sequence[AuditEntry],
+    ) -> None:
+        """Schedule an audit write for a mutation that has already succeeded.
+
+        Synchronous and returns immediately: identity is read here, on the
+        request's own task, because ``request.state`` is torn down once the
+        response is sent. Everything else happens on a background task.
+
+        Does not raise, so callers can put it on a success path unwrapped.
+        """
+        try:
+            # get_current_user returns (role_id, user_id, session_id) — that
+            # order reads backwards, so unpack into named locals and pass by
+            # keyword, which makes a transposition visible at review.
+            role_id, user_id, _session_id = get_current_user(request)
+            actor = AuditActor(
+                user_id=user_id,
+                role_id=role_id,
+                request_id=get_current_request_id(),
+            )
+            # The mutation committed now; the row may be written seconds later,
+            # and a trail timestamped by write time cannot be ordered against
+            # anything else.
+            occurred_at = datetime.now(timezone.utc).replace(tzinfo=None)
+            self._spawn(
+                self.record(
+                    datasource_id=datasource_id,
+                    datasource_type=datasource_type,
+                    operation=operation,
+                    entries=entries,
+                    actor=actor,
+                    occurred_at=occurred_at,
+                )
+            )
+        except Exception:
+            # Best-effort by contract: this runs on the success path of a
+            # mutation that already committed, so nothing it can go wrong at may
+            # turn a 200 into a 500.
+            logger.error('Failed to schedule datasource audit write')
+
+    async def record(
+        self,
+        *,
+        datasource_id: str,
+        datasource_type: str,
+        operation: str,
+        entries: Sequence[AuditEntry],
+        actor: AuditActor,
+        occurred_at: datetime,
+        batch_id: Optional[uuid.UUID] = None,
+    ) -> None:
+        """Write the audit rows. Awaitable, for tests and any blocking caller."""
+        try:
+            # A statement that matched nothing is a success but not a change,
+            # and this table records changes. Filtering here rather than at the
+            # five call sites keeps the rule in one place — it matters on the
+            # multi-table path, where require_all_matched=False lets some
+            # entries match and others not.
+            recordable = [entry for entry in entries if entry.rows_affected > 0]
+            if not recordable:
+                return
+
+            batch_id = batch_id or uuid.uuid4()
+            records = [
+                self._build_record(
+                    entry=entry,
+                    batch_id=batch_id,
+                    datasource_id=datasource_id,
+                    datasource_type=datasource_type,
+                    operation=operation,
+                    actor=actor,
+                    occurred_at=occurred_at,
+                )
+                for entry in recordable
+            ]
+
+            # create_all opens one session and commits once, so a multi-table
+            # request's audit rows land together or not at all — matching the
+            # atomicity of the mutation they describe. create() would open one
+            # session per row and could half-succeed.
+            await self.audit_log_repository.create_all(records)
+        except Exception as e:
+            logger.error(f'Failed to write datasource audit rows: {e}')
+
+    def _spawn(self, coro) -> None:
+        task = asyncio.create_task(coro)
+        _pending_audit_tasks.add(task)
+        task.add_done_callback(_pending_audit_tasks.discard)
+        task.add_done_callback(_log_audit_task_result)
+
+    def _build_record(
+        self,
+        *,
+        entry: AuditEntry,
+        batch_id: uuid.UUID,
+        datasource_id: str,
+        datasource_type: str,
+        operation: str,
+        actor: AuditActor,
+        occurred_at: datetime,
+    ) -> DatasourceAuditLog:
+        changes, truncation_reason = self._build_changes(entry)
+        audit_filter, filter_truncated = self._clip_filter(entry.filter)
+
+        meta = dict(entry.meta)
+        if truncation_reason:
+            meta['truncation_reason'] = truncation_reason
+        if filter_truncated:
+            meta['filter_truncated'] = True
+        # Only meaningful for updates: an insert has no prior state and a
+        # delete's rows already are one, so their missing before is not a gap.
+        # Recorded so a consumer can tell "this update has no diff because the
+        # read failed" from "diffs are not a thing here".
+        if entry.snapshot == 'after' and entry.before_rows is None:
+            meta['before_capture'] = 'unavailable'
+
+        return DatasourceAuditLog(
+            batch_id=batch_id,
+            # Coerced rather than passed through as the path-param string: the
+            # column is uuid, and relying on the driver to infer a text->uuid
+            # cast would make a malformed id fail inside the background task,
+            # where the only symptom is a log line.
+            datasource_id=uuid.UUID(str(datasource_id)),
+            datasource_type=datasource_type,
+            table_name=entry.table_name,
+            operation=operation,
+            filter=audit_filter,
+            # Through the same normaliser as the row payload: an `in` filter
+            # binds a list, and a numeric comparison binds a Decimal on some
+            # paths, neither of which a jsonb column takes as-is.
+            filter_params=serialize_values(entry.filter_params)
+            if entry.filter_params
+            else None,
+            changes=changes,
+            meta=meta or None,
+            rows_affected=entry.rows_affected,
+            user_id=actor.user_id,
+            role_id=actor.role_id,
+            request_id=actor.request_id,
+            created_at=occurred_at,
+        )
+
+    @staticmethod
+    def _clip_filter(value: Optional[str]) -> Tuple[Optional[str], bool]:
+        """Fit the filter into the column, reporting whether it had to be cut.
+
+        The column is VARCHAR(512) and would reject a longer value outright,
+        failing the whole insert. An over-length filter has to cost fidelity,
+        never the audit row.
+        """
+        if value is None or len(value) <= AUDIT_FILTER_MAX_CHARS:
+            return value, False
+        return value[:AUDIT_FILTER_MAX_CHARS], True
+
+    def _build_diff(self, entry: AuditEntry) -> Dict[str, Any]:
+        """Pair each row's prior values against what it became.
+
+        The two row sets come from separate statements, so they arrive in
+        whatever order the planner produced. Pairing by primary key is what makes
+        a multi-row update meaningful — positionally, row 3's old value could
+        easily be attributed to row 1.
+
+        ``correlated: false`` marks the cases where no key is usable and the
+        pairing falls back to position. That is unambiguous for a single-row
+        update, which is the overwhelmingly common shape, and the flag tells a
+        consumer not to trust it beyond that.
+        """
+        before_rows = entry.before_rows or []
+        after_rows = entry.rows or []
+        declared_key = entry.key_columns or []
+
+        # A key column that is itself being updated changes value, so the two
+        # sides no longer share it: pairing on it would silently mismatch rows.
+        # It stops being a key and becomes an ordinary changed column — which is
+        # why `key` is emptied here rather than merely ignored, or the one column
+        # that actually moved would be stripped out of before/after.
+        correlated = bool(declared_key) and not any(
+            column in (entry.meta or {}).get('patch', {}) for column in declared_key
+        )
+        key_columns = declared_key if correlated else []
+
+        def _split(row):
+            key = {c: row[c] for c in key_columns if c in row}
+            values = {c: v for c, v in row.items() if c not in key_columns}
+            return key, values
+
+        def _key_of(key):
+            return tuple(key.get(c) for c in key_columns)
+
+        rows: List[Dict[str, Any]] = []
+        if correlated:
+            before_by_key = {}
+            for row in before_rows:
+                key, values = _split(row)
+                before_by_key[_key_of(key)] = values
+            for row in after_rows:
+                key, values = _split(row)
+                # None, not {}: a row can be updated without a captured prior
+                # value when the pre-read was capped, and that is not the same
+                # as having had no values.
+                rows.append(
+                    {
+                        'key': key,
+                        'before': before_by_key.get(_key_of(key)),
+                        'after': values,
+                    }
+                )
+        else:
+            for index, row in enumerate(after_rows):
+                _, values = _split(row)
+                before = before_rows[index] if index < len(before_rows) else None
+                rows.append({'key': None, 'before': before, 'after': values})
+
+        columns = sorted(
+            {c for row in after_rows for c in row if c not in key_columns}
+            or {c for row in before_rows for c in row if c not in key_columns}
+        )
+
+        return {
+            'snapshot': 'diff',
+            'columns': columns,
+            'key_columns': key_columns or None,
+            'correlated': correlated,
+            'rows': rows,
+        }
+
+    def _build_changes(
+        self, entry: AuditEntry
+    ) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+        """Build the `changes` document, applying whatever caps are configured."""
+        if entry.rows is None:
+            # No capture was available. A null `changes` says exactly that; an
+            # empty rows list would instead claim the mutation touched nothing.
+            return None, 'capture_unavailable'
+
+        # An update with a prior read becomes a diff; everything else keeps its
+        # own snapshot shape. When the before-capture failed this falls through
+        # to the after-only document rather than losing the record.
+        if entry.snapshot == 'after' and entry.before_rows is not None:
+            document = self._build_diff(entry)
+        else:
+            document = {'snapshot': entry.snapshot, 'rows': entry.rows}
+
+        rows = document['rows']
+        # A cap the client already applied counts as a row cap: it stopped
+        # fetching for the same reason we would have stopped storing.
+        reason: Optional[str] = 'row_cap' if entry.truncated else None
+
+        if self.max_rows is not None and len(rows) > self.max_rows:
+            rows = rows[: self.max_rows]
+            reason = 'row_cap'
+
+        rows = self._json_safe(rows)
+
+        if self.max_payload_bytes is not None:
+            # Halving rather than dropping one row at a time: measuring per row
+            # is O(n) encodes of an already-large payload, this is O(log n).
+            while rows and self._encoded_size(rows) > self.max_payload_bytes:
+                rows = rows[: len(rows) // 2]
+                reason = 'size_cap'
+            if not rows and entry.rows:
+                # Even a single row blew the cap. Storing a partially serialized
+                # row would be worse than storing none — half a row reads as a
+                # whole one.
+                reason = 'row_exceeds_size_cap'
+
+        document['rows'] = rows
+        return document, reason
+
+    @staticmethod
+    def _encoded_size(rows: List[Dict[str, Any]]) -> int:
+        return len(json.dumps(rows, separators=(',', ':')).encode('utf-8'))
+
+    @classmethod
+    def _json_safe(cls, rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Reduce captured rows to values a jsonb column will accept.
+
+        serialize_values is reused rather than reimplemented, but it covers only
+        the common arrivals (UUID, date/datetime, Decimal, dict, list) — not
+        bytea (bytes/memoryview), time, interval, inet or range types. The
+        dumps/loads round trip with default=str catches those in one pass and
+        normalises the result to primitives, so nothing exotic reaches the
+        driver.
+
+        Non-finite floats need separate handling, because a round trip does not
+        remove them: json.dumps emits a bare ``NaN`` and json.loads parses it
+        straight back into float('nan'), which Postgres jsonb then rejects,
+        failing the whole insert. allow_nan=False turns that into a ValueError
+        we can catch, and the retry stringifies them first.
+        """
+        pre = [serialize_values(row) for row in rows]
+        try:
+            return json.loads(json.dumps(pre, default=str, allow_nan=False))
+        except ValueError:
+            sanitized = [cls._replace_non_finite(row) for row in pre]
+            return json.loads(json.dumps(sanitized, default=str, allow_nan=False))
+
+    @classmethod
+    def _replace_non_finite(cls, value: Any) -> Any:
+        """Recursively replace NaN/Infinity with their string form.
+
+        Only walked on the rare row that actually contains one — the common path
+        never pays for this.
+        """
+        if isinstance(value, float) and not math.isfinite(value):
+            return str(value)
+        if isinstance(value, dict):
+            return {key: cls._replace_non_finite(item) for key, item in value.items()}
+        if isinstance(value, list):
+            return [cls._replace_non_finite(item) for item in value]
+        return value

--- a/wavefront/server/packages/flo_cloud/flo_cloud/postgres/__init__.py
+++ b/wavefront/server/packages/flo_cloud/flo_cloud/postgres/__init__.py
@@ -1,3 +1,3 @@
-from .postgres import NoRowsMatchedError, PostgresClient
+from .postgres import NoRowsMatchedError, PostgresClient, RowMutationResult
 
-__all__ = ['NoRowsMatchedError', 'PostgresClient']
+__all__ = ['NoRowsMatchedError', 'PostgresClient', 'RowMutationResult']

--- a/wavefront/server/packages/flo_cloud/flo_cloud/postgres/postgres.py
+++ b/wavefront/server/packages/flo_cloud/flo_cloud/postgres/postgres.py
@@ -1,7 +1,8 @@
 import re
 import string
 import logging
-from typing import List, Dict, Any, Optional, Tuple
+from dataclasses import dataclass
+from typing import List, Dict, Any, Optional, Sequence, Tuple
 from contextlib import contextmanager
 
 import psycopg2
@@ -18,6 +19,38 @@ class NoRowsMatchedError(Exception):
     but one addressed a row that does not exist. The transaction is rolled back
     before this is raised, so nothing was written.
     """
+
+
+@dataclass(frozen=True)
+class RowMutationResult:
+    """What a row-level UPDATE or DELETE did.
+
+    ``rows_affected`` always comes from ``cursor.rowcount``, which RETURNING does
+    not change and which fetching does not consume — so the count stays exact
+    however few of the rows are actually pulled into memory.
+
+    ``rows`` is None when the caller did not ask to capture, and [] when it did
+    and nothing matched. Those are different facts, and a caller recording an
+    audit trail must not conflate them.
+    """
+
+    rows_affected: int
+    rows: Optional[List[Dict[str, Any]]] = None
+    truncated: bool = False
+    table_name: Optional[str] = None
+    # The predicate's column -> value pairs, as parsed. Filled in a layer up by
+    # DatasourcePlugin, which is where an OData filter becomes a where clause;
+    # this class only ever receives the compiled form.
+    filter_params: Optional[Dict[str, Any]] = None
+    # The affected rows as they were *before* an update, read under FOR UPDATE in
+    # the same transaction. None when not captured or when the capture failed —
+    # distinct from [], which means the capture ran and matched nothing. Updates
+    # only: an insert has no prior state, and a delete's `rows` already is one.
+    before_rows: Optional[List[Dict[str, Any]]] = None
+    # The table's primary key columns, present in both `before_rows` and `rows`
+    # so the two can be paired. [] when the table has no primary key, in which
+    # case the caller has nothing to pair on.
+    key_columns: Optional[List[str]] = None
 
 
 class PostgresClient:
@@ -100,7 +133,7 @@ class PostgresClient:
                     cursor.close()
 
     @contextmanager
-    def _write_cursor(self, operation: str = 'Write'):
+    def _write_cursor(self, operation: str = 'Write', dict_rows: bool = False):
         """Yield a cursor on a connection that commits when the block exits.
 
         The read helpers cannot stand in for this: ``execute_query`` fetches
@@ -111,9 +144,14 @@ class PostgresClient:
 
         ``operation`` only labels the log line, so 'Insert error' and 'Update
         error' stay greppable.
+
+        ``dict_rows`` swaps in RealDictCursor so a RETURNING clause comes back as
+        dicts rather than positional tuples — the same mechanism ``get_cursor``
+        already uses on the read path. Only the capturing paths need it; the
+        plain cursor stays the default so nothing else pays for it.
         """
         with self.get_connection() as conn:
-            cursor = conn.cursor()
+            cursor = conn.cursor(**self._cursor_kwargs(dict_rows))
             try:
                 yield cursor
                 conn.commit()
@@ -123,6 +161,137 @@ class PostgresClient:
                 raise
             finally:
                 cursor.close()
+
+    @staticmethod
+    def _cursor_kwargs(dict_rows: bool) -> Dict[str, Any]:
+        """Cursor kwargs for a write.
+
+        Returned as a dict rather than passing ``cursor_factory=None`` so that
+        the non-capturing path is byte-for-byte the ``conn.cursor()`` call it has
+        always been.
+        """
+        return {'cursor_factory': psycopg2.extras.RealDictCursor} if dict_rows else {}
+
+    @staticmethod
+    def _fetch_returned(
+        cursor, capture_limit: Optional[int]
+    ) -> Tuple[List[Dict[str, Any]], bool]:
+        """Pull the RETURNING rows, and say whether more were left behind.
+
+        ``capture_limit`` of None takes everything. With a limit set, one extra
+        row is fetched rather than trusting rowcount for the truncation
+        decision: the extra row is direct evidence, costs one row, and is
+        discarded.
+
+        RealDictRow is a dict subclass, but the rows are copied into plain dicts
+        so that nothing downstream — json, a JSONB adapter — has to care.
+        """
+        if capture_limit is None:
+            return [dict(row) for row in cursor.fetchall()], False
+
+        fetched = cursor.fetchmany(capture_limit + 1)
+        truncated = len(fetched) > capture_limit
+        return [dict(row) for row in fetched[:capture_limit]], truncated
+
+    @staticmethod
+    def _primary_key_columns(cursor, table_name: str) -> List[str]:
+        """The table's primary key columns, in key order. [] if it has none.
+
+        ``::regclass`` resolves a bare or schema-qualified name against the
+        current search_path, which is the same resolution the statements around
+        it get.
+        """
+        cursor.execute(
+            'SELECT a.attname AS attname '
+            'FROM pg_index i '
+            'JOIN LATERAL unnest(i.indkey) WITH ORDINALITY AS k(attnum, ord) '
+            '  ON true '
+            'JOIN pg_attribute a '
+            '  ON a.attrelid = i.indrelid AND a.attnum = k.attnum '
+            'WHERE i.indrelid = %(table)s::regclass AND i.indisprimary '
+            'ORDER BY k.ord',
+            {'table': table_name},
+        )
+        return [row['attname'] for row in cursor.fetchall()]
+
+    def _capture_before(
+        self,
+        cursor,
+        table_name: str,
+        columns: List[str],
+        where_clause: str,
+        params: Optional[Dict[str, Any]],
+        capture_limit: Optional[int],
+    ) -> Tuple[Optional[List[Dict[str, Any]]], List[str]]:
+        """Read the rows an UPDATE is about to change, before it changes them.
+
+        Postgres cannot return OLD values from a plain ``UPDATE ... RETURNING``
+        before v18, so the prior state has to be read separately. Running it on
+        the caller's cursor — same connection, same transaction — with FOR UPDATE
+        is what makes that safe: the matched rows are locked, so nothing can
+        modify them between this read and the UPDATE that follows.
+
+        The whole thing sits inside a savepoint. A failed statement aborts the
+        entire Postgres transaction, so without one a pre-read that errors (a
+        view, a lock timeout, a missing SELECT grant) would take the caller's
+        UPDATE down with it — turning a working mutation into a 500 for the sake
+        of an audit detail. On failure this rolls back to the savepoint and
+        returns None, and the update proceeds exactly as it would have.
+
+        Returns ``(before_rows, key_columns)``.
+        """
+        cursor.execute('SAVEPOINT audit_before')
+        try:
+            key_columns = self._primary_key_columns(cursor, table_name)
+            # The key travels with the values so the caller can pair these rows
+            # against the post-update ones; without it a multi-row update has no
+            # way to tell which before belongs to which after.
+            projection = [*key_columns, *(c for c in columns if c not in key_columns)]
+
+            converted_where, _ = self._convert_named_params(where_clause, params or {})
+
+            query = sql.SQL('SELECT {cols} FROM {table} WHERE {where}').format(
+                cols=sql.SQL(', ').join(sql.Identifier(c) for c in projection),
+                table=sql.Identifier(*table_name.split('.')),
+                where=sql.SQL(converted_where),
+            )
+            if key_columns:
+                # Two jobs: it makes a capped subset deterministic rather than
+                # whichever rows the scan happened to reach first, and it gives
+                # concurrent updates a consistent lock order, which is what stops
+                # FOR UPDATE from introducing deadlocks between requests whose
+                # filters overlap.
+                query = query + sql.SQL(' ORDER BY {cols}').format(
+                    cols=sql.SQL(', ').join(sql.Identifier(c) for c in key_columns)
+                )
+            if capture_limit is not None:
+                query = query + sql.SQL(' LIMIT {n}').format(
+                    n=sql.Literal(capture_limit)
+                )
+            # Last, after ORDER BY and LIMIT, so only the returned rows are
+            # locked rather than everything the predicate matched.
+            query = query + sql.SQL(' FOR UPDATE')
+
+            cursor.execute(query, params or None)
+            before_rows = [dict(row) for row in cursor.fetchall()]
+            cursor.execute('RELEASE SAVEPOINT audit_before')
+            return before_rows, key_columns
+        except Exception as e:
+            # Deliberately every exception, not just psycopg2.Error. The promise
+            # this method makes is that capturing a diff cannot break the
+            # mutation, and a TypeError from an unexpected row shape would break
+            # it just as thoroughly as a failed statement would.
+            #
+            # Warning, not error: the mutation is unaffected and about to
+            # succeed. Only the diff is lost.
+            logger.warning(f'Audit before-capture failed for {table_name}: {e}')
+            try:
+                cursor.execute('ROLLBACK TO SAVEPOINT audit_before')
+            except psycopg2.Error:
+                # The connection itself is gone. Nothing left to salvage here —
+                # let the UPDATE below surface it as the real failure.
+                logger.warning('Could not roll back to the audit savepoint')
+            return None, []
 
     def execute_query(
         self, query: str, params: Optional[Dict[str, Any]] = None
@@ -401,12 +570,30 @@ class PostgresClient:
         with self._write_cursor('Insert') as cursor:
             cursor.executemany(query, serialized)
 
+    @staticmethod
+    def _validate_update(data: Dict[str, Any], where_clause: str) -> None:
+        """Refuse an UPDATE that cannot be safely built.
+
+        Split out of ``_build_update`` so callers can run it *before* opening a
+        connection: the statement can only be built once the primary key is
+        known, and that lookup needs a cursor, so without this a malformed
+        request would connect just to raise.
+
+        An empty ``where_clause`` is the one that matters — it is the last line
+        of defence against an UPDATE that rewrites the whole table.
+        """
+        if not data:
+            raise ValueError('No columns to update')
+        if not where_clause or not where_clause.strip():
+            raise ValueError('A where clause is required to update rows')
+
     def _build_update(
         self,
         table_name: str,
         data: Dict[str, Any],
         where_clause: str,
         params: Optional[Dict[str, Any]] = None,
+        returning_columns: Optional[Sequence[str]] = None,
     ) -> Tuple[Any, Dict[str, Any]]:
         """Build the parameterized UPDATE and its merged parameters.
 
@@ -421,14 +608,24 @@ class PostgresClient:
         and an unprefixed collision would silently feed one side of the statement
         the other side's value.
 
+        ``returning_columns`` appends a RETURNING clause naming exactly those
+        columns, so the statement hands back the rows it updated instead of only
+        a count. It is the same single statement either way — no extra round
+        trip, and nothing to race against. None omits the clause entirely.
+
+        Callers name the columns rather than using ``*``. Only the SET columns
+        can have changed, and a wide table makes the difference stark: returning
+        ``*`` to record a single integer would carry back — and store — every
+        jsonb blob on the row alongside it. A trigger that rewrites one of these
+        values still shows up, because the value comes from the row rather than
+        from the caller's input. Capturing callers also pass the primary key, so
+        the rows can be paired against a pre-update read.
+
         An empty ``where_clause`` is refused. Callers should never construct one —
         this is the last line of defence against an UPDATE that rewrites the whole
         table.
         """
-        if not data:
-            raise ValueError('No columns to update')
-        if not where_clause or not where_clause.strip():
-            raise ValueError('A where clause is required to update rows')
+        self._validate_update(data, where_clause)
 
         set_params = {
             f'set_{col}': psycopg2.extras.Json(value)
@@ -452,6 +649,13 @@ class PostgresClient:
             where=sql.SQL(converted_where),
         )
 
+        if returning_columns:
+            query = query + sql.SQL(' RETURNING {columns}').format(
+                columns=sql.SQL(', ').join(
+                    sql.Identifier(col) for col in returning_columns
+                )
+            )
+
         return query, {**set_params, **(params or {})}
 
     def update_rows_json(
@@ -460,22 +664,67 @@ class PostgresClient:
         data: Dict[str, Any],
         where_clause: str,
         params: Optional[Dict[str, Any]] = None,
-    ) -> int:
-        """Update the rows matching ``where_clause``, returning how many changed."""
-        query, merged_params = self._build_update(
-            table_name, data, where_clause, params
-        )
+        capture: bool = False,
+        capture_limit: Optional[int] = None,
+    ) -> RowMutationResult:
+        """Update the rows matching ``where_clause``.
 
-        with self._write_cursor('Update') as cursor:
+        ``capture`` opts into RETURNING, putting the updated rows on the result —
+        restricted to the columns in ``data``, which are the only ones this
+        statement can have changed. It also reads those columns' prior values
+        first, so the result carries a before as well as an after. Left False —
+        the default — the statement issued is exactly the one this method has
+        always issued, ``rows`` is None and no pre-read happens, so a caller that
+        only wants the count pays for none of it. ``capture_limit`` bounds how
+        many rows are materialized on both sides; None takes all of them.
+        """
+        # Ahead of the connection: the statement cannot be built until the
+        # primary key is known, and that needs a cursor.
+        self._validate_update(data, where_clause)
+
+        with self._write_cursor('Update', dict_rows=capture) as cursor:
+            before_rows: Optional[List[Dict[str, Any]]] = None
+            key_columns: List[str] = []
+            if capture:
+                before_rows, key_columns = self._capture_before(
+                    cursor, table_name, list(data), where_clause, params, capture_limit
+                )
+
+            returning_columns = (
+                [*key_columns, *(c for c in data if c not in key_columns)]
+                if capture
+                else None
+            )
+            query, merged_params = self._build_update(
+                table_name,
+                data,
+                where_clause,
+                params,
+                returning_columns=returning_columns,
+            )
+
             cursor.execute(query, merged_params)
-            return cursor.rowcount
+            rows_affected = cursor.rowcount
+            if not capture:
+                return RowMutationResult(rows_affected=rows_affected)
+            rows, truncated = self._fetch_returned(cursor, capture_limit)
+            return RowMutationResult(
+                rows_affected,
+                rows,
+                truncated,
+                table_name,
+                before_rows=before_rows,
+                key_columns=key_columns,
+            )
 
     def delete_rows_json(
         self,
         table_name: str,
         where_clause: str,
         params: Optional[Dict[str, Any]] = None,
-    ) -> int:
+        capture: bool = False,
+        capture_limit: Optional[int] = None,
+    ) -> RowMutationResult:
         """Delete the rows matching ``where_clause``, returning how many went.
 
         ``where_clause`` is a parameterized predicate (from the OData parser) using
@@ -483,6 +732,11 @@ class PostgresClient:
         contract as ``update_rows_json``, minus the SET side, so there is no
         ``set_`` prefixing to do and the parser's parameters can be used as they
         come.
+
+        ``capture`` opts into RETURNING, putting the deleted rows on the result.
+        It matters more here than on the update: after this commits those rows do
+        not exist anywhere else, so a caller that wants a record of them has no
+        second chance to read them.
 
         An empty ``where_clause`` is refused. A DELETE without a WHERE empties the
         table, and unlike an UPDATE there is no prior value left to reconstruct it
@@ -498,20 +752,29 @@ class PostgresClient:
             where=sql.SQL(converted_where),
         )
 
-        with self._write_cursor('Delete') as cursor:
+        if capture:
+            query = query + sql.SQL(' RETURNING *')
+
+        with self._write_cursor('Delete', dict_rows=capture) as cursor:
             # `or None`, not `or {}`: psycopg2 skips interpolation entirely when
             # params is None, but an empty dict still triggers it and then trips
             # over any literal '%' in a hand-written predicate. Callers coming
             # through the OData parser always bind something, so this only
             # matters to direct users of this class.
             cursor.execute(query, params or None)
-            return cursor.rowcount
+            rows_affected = cursor.rowcount
+            if not capture:
+                return RowMutationResult(rows_affected=rows_affected)
+            rows, truncated = self._fetch_returned(cursor, capture_limit)
+            return RowMutationResult(rows_affected, rows, truncated, table_name)
 
     def update_rows_json_multi(
         self,
         updates: List[Dict[str, Any]],
         require_all_matched: bool = True,
-    ) -> List[Dict[str, Any]]:
+        capture: bool = False,
+        capture_limit: Optional[int] = None,
+    ) -> List[RowMutationResult]:
         """Update rows across multiple tables atomically, in one transaction.
 
         ``updates`` is a list of
@@ -528,45 +791,91 @@ class PostgresClient:
         to prevent. Default is therefore to roll back and raise; pass False for
         best-effort semantics.
 
-        Returns one ``{"table_name": str, "updated_rows": int}`` per entry, in
-        order.
+        ``capture`` opts every entry into RETURNING, as on the single-table
+        methods.
+
+        Returns one ``RowMutationResult`` per entry, in order.
         """
         if not updates:
             return []
 
-        prepared = [
-            (
-                spec['table_name'],
-                self._build_update(
-                    spec['table_name'],
-                    spec['data'],
-                    spec['where_clause'],
-                    spec.get('params'),
-                ),
-            )
-            for spec in updates
-        ]
+        # Every entry is checked before a single statement runs, so an invalid
+        # one cannot leave a partially applied transaction behind. The statements
+        # themselves can only be built inside the loop, once each table's primary
+        # key is known.
+        for spec in updates:
+            self._validate_update(spec['data'], spec['where_clause'])
 
         # Keeps its own connection block rather than using _write_cursor: it has
         # to decide whether to commit *after* inspecting the row counts, and its
         # rollback path raises NoRowsMatchedError, which is an expected 409 rather
         # than a failure worth an error log.
         with self.get_connection() as conn:
-            cursor = conn.cursor()
+            cursor = conn.cursor(**self._cursor_kwargs(capture))
             try:
-                results = []
-                for table_name, (query, merged_params) in prepared:
+                results: List[RowMutationResult] = []
+                for spec in updates:
+                    table_name = spec['table_name']
+                    data = spec['data']
+                    where_clause = spec['where_clause']
+                    params = spec.get('params')
+
+                    before_rows: Optional[List[Dict[str, Any]]] = None
+                    key_columns: List[str] = []
+                    if capture:
+                        before_rows, key_columns = self._capture_before(
+                            cursor,
+                            table_name,
+                            list(data),
+                            where_clause,
+                            params,
+                            capture_limit,
+                        )
+
+                    returning_columns = (
+                        [*key_columns, *(c for c in data if c not in key_columns)]
+                        if capture
+                        else None
+                    )
+                    query, merged_params = self._build_update(
+                        table_name,
+                        data,
+                        where_clause,
+                        params,
+                        returning_columns=returning_columns,
+                    )
+
                     cursor.execute(query, merged_params)
+                    rows_affected = cursor.rowcount
+                    if not capture:
+                        results.append(
+                            RowMutationResult(
+                                rows_affected=rows_affected, table_name=table_name
+                            )
+                        )
+                        continue
+                    # Drained before the next execute: a cursor holds only the
+                    # most recent result set, so deferring this would lose every
+                    # entry but the last.
+                    rows, truncated = self._fetch_returned(cursor, capture_limit)
                     results.append(
-                        {'table_name': table_name, 'updated_rows': cursor.rowcount}
+                        RowMutationResult(
+                            rows_affected,
+                            rows,
+                            truncated,
+                            table_name,
+                            before_rows=before_rows,
+                            key_columns=key_columns,
+                        )
                     )
 
                 if require_all_matched:
-                    unmatched = [
-                        r['table_name'] for r in results if not r['updated_rows']
-                    ]
+                    unmatched = [r.table_name for r in results if not r.rows_affected]
                     if unmatched:
                         conn.rollback()
+                        # Any rows captured above are discarded along with the
+                        # transaction, deliberately: nothing was committed, so
+                        # there is no change for a caller to record.
                         raise NoRowsMatchedError(
                             'No rows matched the filter for: '
                             f'{", ".join(unmatched)}. Nothing was updated.'

--- a/wavefront/server/plugins/datasource/datasource/__init__.py
+++ b/wavefront/server/plugins/datasource/datasource/__init__.py
@@ -5,7 +5,10 @@ from .types import (
     TableListResult,
     QueryResult,
 )
+from dataclasses import replace
 from typing import Any, Optional, List, Dict
+
+from flo_cloud.postgres import RowMutationResult
 
 from .bigquery import BigQueryPlugin, BigQueryConfig
 from .redshift import RedshiftPlugin, RedshiftConfig
@@ -107,9 +110,14 @@ class DatasourcePlugin:
         return self.datasource.insert_rows_json_multi(inserts)
 
     def update_rows_json(
-        self, table_name: str, data: Dict[str, Any], filter: str
-    ) -> int:
-        """Update the rows matching the OData ``filter``, returning how many changed.
+        self,
+        table_name: str,
+        data: Dict[str, Any],
+        filter: str,
+        capture: bool = False,
+        capture_limit: Optional[int] = None,
+    ) -> RowMutationResult:
+        """Update the rows matching the OData ``filter``.
 
         Unlike ``fetch_data``, which falls back to a '1=1' no-op predicate when no
         filter is given, an absent or unparseable filter is an error here: an
@@ -119,13 +127,21 @@ class DatasourcePlugin:
         where_clause, params = self.odata_parser.prepare_odata_filter(filter)
         if not where_clause:
             raise ValueError('A filter is required to update rows')
-        return self.datasource.update_rows_json(
-            table_name, data, where_clause, params or {}
+        result = self.datasource.update_rows_json(
+            table_name, data, where_clause, params or {}, capture, capture_limit
         )
+        # Attached here rather than deeper down because this is the only layer
+        # that sees the filter as OData: below it the predicate is already
+        # compiled, and the column -> value pairs cannot be recovered from it.
+        return replace(result, filter_params=params or None)
 
     def update_rows_json_multi(
-        self, updates: List[Dict[str, Any]], require_all_matched: bool = True
-    ) -> List[Dict[str, Any]]:
+        self,
+        updates: List[Dict[str, Any]],
+        require_all_matched: bool = True,
+        capture: bool = False,
+        capture_limit: Optional[int] = None,
+    ) -> List[RowMutationResult]:
         """Update rows across several tables atomically.
 
         ``updates``: list of ``{"table_name", "data", "filter"}``, where ``filter``
@@ -150,10 +166,24 @@ class DatasourcePlugin:
                     'params': params or {},
                 }
             )
-        return self.datasource.update_rows_json_multi(prepared, require_all_matched)
+        results = self.datasource.update_rows_json_multi(
+            prepared, require_all_matched, capture, capture_limit
+        )
+        # `prepared` and `results` are index-aligned: one result per entry, in
+        # order.
+        return [
+            replace(result, filter_params=spec['params'] or None)
+            for result, spec in zip(results, prepared)
+        ]
 
-    def delete_rows_json(self, table_name: str, filter: str) -> int:
-        """Delete the rows matching the OData ``filter``, returning how many went.
+    def delete_rows_json(
+        self,
+        table_name: str,
+        filter: str,
+        capture: bool = False,
+        capture_limit: Optional[int] = None,
+    ) -> RowMutationResult:
+        """Delete the rows matching the OData ``filter``.
 
         Same rule as ``update_rows_json``, and for a stronger reason: an absent or
         unparseable filter is an error, never a no-op predicate, because a DELETE
@@ -195,7 +225,10 @@ class DatasourcePlugin:
                 f'({", ".join(sorted(blank))}): it would match every row'
             )
 
-        return self.datasource.delete_rows_json(table_name, where_clause, params)
+        result = self.datasource.delete_rows_json(
+            table_name, where_clause, params, capture, capture_limit
+        )
+        return replace(result, filter_params=params or None)
 
     async def execute_query(
         self, query: str, use_legacy_sql: bool = False, dry_run: bool = False, **kwargs

--- a/wavefront/server/plugins/datasource/datasource/postgres/__init__.py
+++ b/wavefront/server/plugins/datasource/datasource/postgres/__init__.py
@@ -3,7 +3,7 @@ import re
 from typing import Any, Dict, List, Optional
 
 from ..types import DataSourceABC
-from flo_cloud.postgres import PostgresClient
+from flo_cloud.postgres import PostgresClient, RowMutationResult
 from .config import PostgresConfig
 
 
@@ -71,21 +71,35 @@ class PostgresPlugin(DataSourceABC):
         data: Dict[str, Any],
         where_clause: str,
         params: Dict[str, Any],
-    ) -> int:
-        return self.client.update_rows_json(table_name, data, where_clause, params)
+        capture: bool = False,
+        capture_limit: Optional[int] = None,
+    ) -> RowMutationResult:
+        return self.client.update_rows_json(
+            table_name, data, where_clause, params, capture, capture_limit
+        )
 
     def update_rows_json_multi(
-        self, updates: List[Dict[str, Any]], require_all_matched: bool = True
-    ) -> List[Dict[str, Any]]:
-        return self.client.update_rows_json_multi(updates, require_all_matched)
+        self,
+        updates: List[Dict[str, Any]],
+        require_all_matched: bool = True,
+        capture: bool = False,
+        capture_limit: Optional[int] = None,
+    ) -> List[RowMutationResult]:
+        return self.client.update_rows_json_multi(
+            updates, require_all_matched, capture, capture_limit
+        )
 
     def delete_rows_json(
         self,
         table_name: str,
         where_clause: str,
         params: Dict[str, Any],
-    ) -> int:
-        return self.client.delete_rows_json(table_name, where_clause, params)
+        capture: bool = False,
+        capture_limit: Optional[int] = None,
+    ) -> RowMutationResult:
+        return self.client.delete_rows_json(
+            table_name, where_clause, params, capture, capture_limit
+        )
 
     async def execute_query(
         self, query: str, use_legacy_sql: bool = False, dry_run: bool = False, **kwargs

--- a/wavefront/server/plugins/datasource/datasource/types.py
+++ b/wavefront/server/plugins/datasource/datasource/types.py
@@ -3,6 +3,8 @@ from abc import ABC, abstractmethod
 from typing import Any, Generic, TypeVar, List, Dict, Optional
 from dataclasses import dataclass
 
+from flo_cloud.postgres import RowMutationResult
+
 
 @dataclass
 class Meta:
@@ -100,11 +102,14 @@ class DataSourceABC(ABC):
         data: Dict[str, Any],
         where_clause: str,
         params: Dict[str, Any],
-    ) -> int:
-        """Update the rows matching ``where_clause``, returning how many changed.
+        capture: bool = False,
+        capture_limit: Optional[int] = None,
+    ) -> RowMutationResult:
+        """Update the rows matching ``where_clause``.
 
         ``data`` maps column name to new value; ``where_clause`` is a parameterized
-        SQL predicate and ``params`` its values. Concrete (not abstract) with a
+        SQL predicate and ``params`` its values. ``capture`` asks for the updated
+        rows themselves rather than only a count. Concrete (not abstract) with a
         NotImplementedError default, for the same reason as
         ``insert_rows_json_multi``: datasource types that don't support it stay
         instantiable.
@@ -114,8 +119,12 @@ class DataSourceABC(ABC):
         )
 
     def update_rows_json_multi(
-        self, updates: List[Dict[str, Any]], require_all_matched: bool = True
-    ) -> List[Dict[str, Any]]:
+        self,
+        updates: List[Dict[str, Any]],
+        require_all_matched: bool = True,
+        capture: bool = False,
+        capture_limit: Optional[int] = None,
+    ) -> List[RowMutationResult]:
         """Update rows across multiple tables atomically, in one transaction.
 
         ``updates``: list of ``{"table_name", "data", "where_clause", "params"}``.
@@ -131,13 +140,17 @@ class DataSourceABC(ABC):
         table_name: str,
         where_clause: str,
         params: Dict[str, Any],
-    ) -> int:
-        """Delete the rows matching ``where_clause``, returning how many went.
+        capture: bool = False,
+        capture_limit: Optional[int] = None,
+    ) -> RowMutationResult:
+        """Delete the rows matching ``where_clause``.
 
         ``where_clause`` is a parameterized SQL predicate and ``params`` its
-        values. Concrete (not abstract) with a NotImplementedError default, for
-        the same reason as ``insert_rows_json_multi``: datasource types that don't
-        support it stay instantiable.
+        values. ``capture`` asks for the deleted rows themselves — after this
+        commits they exist nowhere else. Concrete (not abstract) with a
+        NotImplementedError default, for the same reason as
+        ``insert_rows_json_multi``: datasource types that don't support it stay
+        instantiable.
         """
         raise NotImplementedError(
             f'{type(self).__name__} does not support deleting rows'


### PR DESCRIPTION
Records every successful insert/update/delete made through the datasource data-plane API into a new `datasource_audit_logs` table in the application database — who made the change, against which datasource and table, the predicate that selected the rows, and the rows themselves.

Those five endpoints previously left no trace: they read no identity and returned only a row count. They also have no admin check and no per-table authorization, so any authenticated principal — including service identities and the agent tools — can write to any table of any configured datasource. Until that changes, this trail is the only control on that surface.

Capture, per operation:

  - insert: the rows as submitted (`snapshot: "submitted"`). Database defaults, triggers and generated columns are not reflected, which the discriminator states rather than implying an after-image.
  - update: a per-row before/after diff of the columns that were SET.
  - delete: the whole row, via `DELETE ... RETURNING *` — after the commit those rows exist nowhere else.

The diff needs more than RETURNING, since Postgres cannot return OLD values before v18. The prior state is read with `SELECT ... FOR UPDATE` on the same connection inside the same transaction, so the rows are locked and cannot change between the read and the write. That read sits inside a SAVEPOINT: a failed statement aborts the whole transaction, so without one a pre-read that errored would take the caller's UPDATE with it. On failure the record degrades to an after-only snapshot and the mutation proceeds untouched.

Before and after rows are paired by primary key, discovered from pg_index and included in both projections; they come from separate statements and arrive in arbitrary order, so pairing positionally could attribute one row's prior value to another. `correlated: false` marks the fallback when the table has no primary key, or when a key column is itself being updated.

Writes are best-effort and out-of-band. The audit row lands in a different database from the one mutated, via a different driver, so the two can never share a transaction. It is written only after the mutation commits and never raises into the caller: a missing record means the audit write lost, not that the mutation did not happen. Zero-row mutations and every failed request (400/404/409/501) are deliberately not recorded.

Payloads are capped at 20 rows / 256 KiB per record, with the limit pushed down to the datasource client so capped rows are never fetched only to be discarded. `rows_affected` comes from cursor.rowcount and is never capped, so the true scale of a change survives truncation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added administrator access to datasource audit logs with filtering, pagination, date ranges, totals, and detailed record retrieval.
  * Datasource inserts, updates, and deletes now record operation details, affected rows, request context, and change snapshots.
  * Update and delete operations can return captured affected rows, including before-images for updates, with configurable limits.
* **Bug Fixes**
  * Preserved existing mutation response behavior while adding audit logging and row-capture capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->