### PR TITLE
feat(agents): persist and return agentic execution variables

### DIFF
--- a/wavefront/server/modules/agents_module/agents_module/controllers/agent_controller.py
+++ b/wavefront/server/modules/agents_module/agents_module/controllers/agent_controller.py
@@ -109,6 +109,7 @@ async def agent_inference(
         agent_id=agent_id,
         namespace=namespace,
         execution_time=execution_time,
+        variables=agent_inference_payload.variables,
     )
 
     logger.info(
@@ -209,6 +210,7 @@ async def agent_inference_v2(
         agent_id=str(agent_id),
         namespace=namespace,
         execution_time=execution_time,
+        variables=agent_inference_payload.variables,
     )
 
     logger.info(f'Successfully completed v2 inference for agent_id: {agent_id}')

--- a/wavefront/server/modules/agents_module/agents_module/controllers/workflow_controller.py
+++ b/wavefront/server/modules/agents_module/agents_module/controllers/workflow_controller.py
@@ -164,6 +164,7 @@ async def workflow_inference(
                     'workflow_id': workflow_id,
                     'namespace': namespace,
                     'execution_time': execution_time,
+                    'variables': request_body.variables,
                     'timestamp': time.time(),
                 }
                 yield f'data: {json.dumps(output_event)}\n\n'
@@ -219,6 +220,9 @@ async def workflow_inference(
             workflow_id=workflow_id,
             namespace=namespace,
             execution_time=execution_time,
+            # The request's variables, not the with_execution_variables() dict:
+            # the internal _wf_execution_id must not leak into the response.
+            variables=request_body.variables,
         )
 
         logger.info(
@@ -375,6 +379,7 @@ async def workflow_inference_v2(
                     'workflow_id': workflow_name,
                     'namespace': namespace,
                     'execution_time': execution_time,
+                    'variables': request_body.variables,
                     'timestamp': time.time(),
                 }
                 yield f'data: {json.dumps(output_event)}\n\n'
@@ -432,6 +437,7 @@ async def workflow_inference_v2(
             workflow_id=workflow_name,
             namespace=namespace,
             execution_time=execution_time,
+            variables=request_body.variables,
         )
 
         logger.info(

--- a/wavefront/server/modules/agents_module/agents_module/models/agent_schemas.py
+++ b/wavefront/server/modules/agents_module/agents_module/models/agent_schemas.py
@@ -48,6 +48,10 @@ class AgentInferenceResponse(BaseModel):
         ..., description='The namespace of the agent that performed the inference'
     )
     execution_time: float = Field(..., description='Execution time in seconds')
+    variables: Dict[str, Any] | None = Field(
+        default=None,
+        description='The variables this inference was run with',
+    )
 
 
 class AgentResponse(BaseModel):

--- a/wavefront/server/modules/agents_module/agents_module/models/async_agentic_execution_schemas.py
+++ b/wavefront/server/modules/agents_module/agents_module/models/async_agentic_execution_schemas.py
@@ -1,6 +1,6 @@
 import uuid
 from datetime import datetime
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
@@ -11,6 +11,7 @@ class AsyncInferenceResponse(BaseModel):
     entity_type: str
     entity_id: uuid.UUID
     status_url: str
+    variables: Optional[Dict[str, Any]] = None
 
 
 class AgenticExecutionStatusResponse(BaseModel):
@@ -20,6 +21,7 @@ class AgenticExecutionStatusResponse(BaseModel):
     celery_task_id: Optional[str] = None
     status: str
     error: Optional[str] = None
+    variables: Optional[Dict[str, Any]] = None
     input_files: Optional[List[Any]] = None
     output_url: Optional[str] = None
     history_url: Optional[str] = None

--- a/wavefront/server/modules/agents_module/agents_module/models/workflow_schemas.py
+++ b/wavefront/server/modules/agents_module/agents_module/models/workflow_schemas.py
@@ -45,6 +45,10 @@ class WorkflowInferenceResponse(BaseModel):
         ..., description='The namespace of the workflow that performed the inference'
     )
     execution_time: float = Field(..., description='Execution time in seconds')
+    variables: Dict[str, Any] | None = Field(
+        default=None,
+        description='The variables this inference was run with',
+    )
 
 
 class WorkflowResponse(BaseModel):

--- a/wavefront/server/modules/agents_module/agents_module/services/async_agentic_execution_service.py
+++ b/wavefront/server/modules/agents_module/agents_module/services/async_agentic_execution_service.py
@@ -191,6 +191,7 @@ class AsyncAgenticExecutionService:
             status='pending',
             input_bucket=self.bucket,
             inputs=json.dumps(clean_inputs),
+            variables=variables,
             input_files=json.dumps(stored_files) if stored_files else None,
         )
 
@@ -232,6 +233,7 @@ class AsyncAgenticExecutionService:
             entity_type='agent',
             entity_id=agent_id,
             status_url=f'/v1/agentic-executions/{execution_id}',
+            variables=variables,
         )
 
     async def create_and_enqueue_workflow(
@@ -260,6 +262,7 @@ class AsyncAgenticExecutionService:
             status='pending',
             input_bucket=self.bucket,
             inputs=json.dumps(clean_inputs),
+            variables=variables,
             input_files=json.dumps(stored_files) if stored_files else None,
         )
 
@@ -305,6 +308,7 @@ class AsyncAgenticExecutionService:
             entity_type='workflow',
             entity_id=workflow_id,
             status_url=f'/v1/agentic-executions/{execution_id}',
+            variables=variables,
         )
 
     def _build_status_response(
@@ -371,6 +375,7 @@ class AsyncAgenticExecutionService:
             celery_task_id=record_dict.get('celery_task_id'),
             status=record_dict['status'],
             error=record_dict.get('error'),
+            variables=record_dict.get('variables'),
             input_files=input_files,
             output_url=output_url,
             history_url=history_url,

--- a/wavefront/server/modules/db_repo_module/db_repo_module/alembic/versions/2026_09_10_1100-c4d8b2e6a917_add_variables_to_async_agentic_executions.py
+++ b/wavefront/server/modules/db_repo_module/db_repo_module/alembic/versions/2026_09_10_1100-c4d8b2e6a917_add_variables_to_async_agentic_executions.py
@@ -1,0 +1,61 @@
+"""add variables jsonb column to async_agentic_executions
+
+An async execution row recorded `inputs` and `input_files` but nothing about the
+`variables` the run was parameterised with, even though variables are the only
+channel that reaches a node's prompt. That made a completed execution
+impossible to audit or reproduce from the row alone.
+
+The column holds the raw variables the caller sent, not the dict handed to the
+worker: `with_execution_variables()` injects an internal `_wf_execution_id` key
+into the Celery payload, and that value is already this row's `id`.
+
+Nullable, because rows predating this column have none and a caller may run
+without variables at all.
+
+The GIN index makes the column queryable by content -- "every execution run for
+customer_id X" -- which a btree on a jsonb column cannot serve. It uses the
+default jsonb_ops rather than jsonb_path_ops: jsonb_path_ops is smaller and
+faster but only supports containment (@>), while jsonb_ops also covers key
+existence (?, ?&, ?|). Callers' variable shapes are arbitrary and no query
+filters on this column yet, so the more permissive operator class is the right
+hedge; narrow it to jsonb_path_ops if containment turns out to be the only
+access pattern.
+
+Revision ID: c4d8b2e6a917
+Revises: f3a91c7e5b02
+Create Date: 2026-09-10 11:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = 'c4d8b2e6a917'
+down_revision: Union[str, None] = 'f3a91c7e5b02'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'async_agentic_executions',
+        sa.Column('variables', postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    )
+    op.create_index(
+        'ix_async_agentic_executions_variables_gin',
+        'async_agentic_executions',
+        ['variables'],
+        postgresql_using='gin',
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        'ix_async_agentic_executions_variables_gin',
+        table_name='async_agentic_executions',
+    )
+    op.drop_column('async_agentic_executions', 'variables')

--- a/wavefront/server/modules/db_repo_module/db_repo_module/models/async_agentic_execution.py
+++ b/wavefront/server/modules/db_repo_module/db_repo_module/models/async_agentic_execution.py
@@ -1,7 +1,9 @@
 import uuid
 from datetime import datetime
+from typing import Any, Optional
 
 from sqlalchemy import Text
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped
 from sqlalchemy.orm import mapped_column
 
@@ -22,6 +24,10 @@ class AsyncAgenticExecution(Base):
     )  # 'pending' | 'in_progress' | 'completed' | 'failed'
     input_bucket: Mapped[str] = mapped_column(nullable=True)
     inputs: Mapped[str] = mapped_column(Text, nullable=True)
+    # The raw variables the caller supplied for this run. Deliberately excludes
+    # the internal `_wf_execution_id` that with_execution_variables() adds to
+    # the worker payload -- the execution id is already this row's `id`.
+    variables: Mapped[Optional[dict[str, Any]]] = mapped_column(JSONB, nullable=True)
     input_files: Mapped[str] = mapped_column(nullable=True)
     output_file: Mapped[str] = mapped_column(nullable=True)
     history_file: Mapped[str] = mapped_column(nullable=True)
@@ -42,6 +48,7 @@ class AsyncAgenticExecution(Base):
             'status': self.status,
             'input_bucket': self.input_bucket,
             'inputs': self.inputs,
+            'variables': self.variables,
             'input_files': self.input_files,
             'output_file': self.output_file,
             'history_file': self.history_file,


### PR DESCRIPTION
`variables` was write-only. On the async path it was accepted, put in the Celery payload, and dropped -- an execution row recorded `inputs` and `input_files` but nothing about the variables the run was parameterised with, even though variables are the only channel that reaches a node's prompt. That made a completed execution impossible to audit or reproduce from the row alone. On the sync path, no inference response echoed back what the run was given.

Add a nullable `variables` JSONB column to async_agentic_executions with a GIN index so the column is queryable by content, and return `variables` from the agent, workflow, and async inference responses.

The column stores the raw caller variables, not the dict handed to the worker: with_execution_variables() injects an internal `_wf_execution_id` key into the payload, and that value is already the row's `id`. The sync controllers echo the request's variables for the same reason, so the internal marker never surfaces in an API response.

_build_status_response reads `variables` with .get rather than a subscript. Status responses are cached as serialized to_dict() output for up to an hour, so entries written before this column existed have no such key and a subscript would 500 until they expired.

No worker or result-consumer changes: the Celery tasks read variables from the payload, never from the DB, and the consumer's terminal-status re-cache picks up the new key via to_dict().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent and workflow inference responses now include the variables supplied with the request.
  * Asynchronous execution responses and status updates now expose the associated request variables.
  * Variables are retained throughout asynchronous executions for consistent visibility across results and status checks.
  * Responses show the original request variables without exposing internal execution identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->